### PR TITLE
chore(.github/workflows/build.yaml): add permission to create a release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+permissions:
+  # Allows the workflow to create releases, upload release assets, and manage repository contents
+  contents: write 
+  
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

1. chore(.github/workflows/build.yaml): add permission to create a release

### Other changes

None.

### Tested

No, can't test until it's on main.

### Related issues

- closes HYP-152

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes.

### Documentation

None.
