### PR TITLE
feat(claudeService): Inferencing code lines and stack traces from logs

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/traceback.iml" filepath="$PROJECT_DIR$/.idea/traceback.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/traceback.iml
+++ b/.idea/traceback.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,9 +9,16 @@
         "--extensionDevelopmentPath=${workspaceFolder}"
       ],
       "outFiles": [
-        "${workspaceFolder}/out/**/*.js"
+        "${workspaceFolder}/dist/**/*.js"
       ],
-      "preLaunchTask": "${defaultBuildTask}"
+      "sourceMaps": true,
+      "preLaunchTask": "npm: compile"
+    }
+  ],
+  "compounds": [
+    {
+      "name": "Extension with Compile",
+      "configurations": ["Run Extension"]
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,16 +3,15 @@
   "tasks": [
     {
       "type": "npm",
-      "script": "watch",
-      "problemMatcher": "$tsc-watch",
-      "isBackground": true,
-      "presentation": {
-        "reveal": "never"
-      },
+      "script": "compile",
       "group": {
         "kind": "build",
         "isDefault": true
-      }
+      },
+      "presentation": {
+        "reveal": "silent"
+      },
+      "problemMatcher": "$tsc"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traceback",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traceback",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@axiomhq/js": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -32,9 +32,20 @@
   "contributes": {
     "configuration": {
       "title": "TraceBack",
-      "properties": {}
+      "properties": {
+          "traceback.claudeApiKey": {
+              "type": "string",
+              "default": "",
+              "description": "API key for Claude AI service"
+          }
+      }
     },
     "commands": [
+      {
+        "command": "traceback.setClaudeApiKey",
+        "title": "Set Claude API Key",
+        "category": "TraceBack"
+      },
       {
         "command": "traceback.filterLogs",
         "title": "Filter Log Levels",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperdrive-eng/traceback.git"

--- a/src/callStackExplorer.ts
+++ b/src/callStackExplorer.ts
@@ -1,5 +1,8 @@
 import * as vscode from 'vscode';
 import { LogEntry, Span, JaegerSpan } from './logExplorer';
+import { CallerAnalysis } from './claudeService';
+import { ClaudeService } from './claudeService';
+import * as path from 'path';
 
 /**
  * TreeItem for call stack entries in the Call Stack Explorer
@@ -12,18 +15,18 @@ export class CallStackTreeItem extends vscode.TreeItem {
   ) {
     // Use span name as the primary label
     super(span.name, collapsibleState);
-    
+
     // Mark as root when appropriate
     this.description = '';
-    
+
     // All spans are shown with standard stack frame icon
     this.iconPath = new vscode.ThemeIcon('debug-stackframe');
-    
+
     // Tooltip with all span properties
     this.tooltip = Object.entries(span)
       .map(([key, value]) => `${key}: ${typeof value === 'object' ? JSON.stringify(value, null, 2) : value}`)
       .join('\n');
-    
+
     // Set context for menu contributions
     this.contextValue = index === 0 ? 'rootSpan' : 'span';
   }
@@ -39,9 +42,9 @@ export class SpanDetailItem extends vscode.TreeItem {
     public readonly contextValue: string = 'spanDetail'
   ) {
     super(label, vscode.TreeItemCollapsibleState.None);
-    
+
     this.description = value;
-    
+
     // Set icon based on property type
     this.iconPath = new vscode.ThemeIcon('symbol-property');
   }
@@ -51,33 +54,35 @@ export class SpanDetailItem extends vscode.TreeItem {
  * Tree data provider for the Call Stack Explorer view
  */
 export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
-  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> = 
+  private _onDidChangeTreeData: vscode.EventEmitter<vscode.TreeItem | undefined | null | void> =
     new vscode.EventEmitter<vscode.TreeItem | undefined | null | void>();
-  
-  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> = 
+
+  readonly onDidChangeTreeData: vscode.Event<vscode.TreeItem | undefined | null | void> =
     this._onDidChangeTreeData.event;
-  
+
   private spans: Span[] = [];
   private currentLogEntry: LogEntry | undefined;
-  
+  private callerAnalysis: CallerAnalysis | undefined;
+  private claudeService: ClaudeService = ClaudeService.getInstance();
+
   constructor(private context: vscode.ExtensionContext) {}
-  
+
   /**
    * Set the spans for the current log entry and refresh the view
    */
   public setLogEntry(logEntry: LogEntry | undefined): void {
     this.currentLogEntry = logEntry;
-    
+
     // Reset spans
     this.spans = [];
-    
+
     if (logEntry) {
       // Case 1: Handle Jaeger spans
       if (logEntry.jaegerSpan) {
         // Build call stack from the references
         const spanId = logEntry.jaegerSpan.spanID;
         const parentSpanID = logEntry.parentSpanID;
-        
+
         // Start with the current span
         const currentSpan: Span = {
           name: logEntry.jaegerSpan.operationName,
@@ -85,14 +90,14 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode
           parent_id: parentSpanID,
           service: logEntry.serviceName
         };
-        
+
         // Add any additional properties from tags
         logEntry.jaegerSpan.tags.forEach(tag => {
           currentSpan[tag.key] = tag.value;
         });
-        
+
         this.spans.push(currentSpan);
-        
+
         // If we have a parent relation, add a parent span too
         if (parentSpanID) {
           const parentSpan: Span = {
@@ -100,7 +105,7 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode
             span_id: parentSpanID,
             service: logEntry.serviceName // Assume same service
           };
-          
+
           this.spans.push(parentSpan);
         }
       }
@@ -110,10 +115,10 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode
         this.spans = [...logEntry.jsonPayload.spans].reverse();
       }
     }
-    
+
     this._onDidChangeTreeData.fire();
   }
-  
+
   /**
    * Clear the call stack
    */
@@ -122,51 +127,353 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode
     this.currentLogEntry = undefined;
     this._onDidChangeTreeData.fire();
   }
-  
+
+  async findPotentialCallers(sourceFile: string, lineNumber: number): Promise<Array<{ filePath: string; lineNumber: number; code: string; functionName: string; functionRange?: vscode.Range }>> {
+    const potentialCallers: Array<{ filePath: string; lineNumber: number; code: string; functionName: string; functionRange?: vscode.Range }> = [];
+    
+    try {
+        // First, get the document
+        const document = await vscode.workspace.openTextDocument(sourceFile);
+        console.log('Document language ID:', document.languageId);
+
+        // For Go files, ensure Go extension is installed and language server is ready
+        if (document.languageId === 'go') {
+            const goExtension = vscode.extensions.getExtension('golang.go');
+            if (!goExtension) {
+                console.log('Go extension not found');
+                vscode.window.showWarningMessage('Go extension is not installed. Some features may not work properly.');
+            } else if (!goExtension.isActive) {
+                console.log('Activating Go extension...');
+                await goExtension.activate();
+            }
+
+            // Wait for Go language server to be ready
+            await new Promise(resolve => setTimeout(resolve, 500));
+        }
+
+        // For Go files, try using the Go-specific symbol provider first
+        let symbols: vscode.DocumentSymbol[] | undefined;
+        
+        if (document.languageId === 'go') {
+            try {
+                // Try Go-specific command for finding symbols
+                const goSymbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                    'go.test.cursor',
+                    document.uri,
+                    new vscode.Position(lineNumber, 0)
+                );
+                console.log('Go-specific symbols:', goSymbols);
+                
+                if (!goSymbols || goSymbols.length === 0) {
+                    // Try gopls workspace symbols
+                    const goplsSymbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+                        'gopls.test.cursor',
+                        document.uri,
+                        new vscode.Position(lineNumber, 0)
+                    );
+                    console.log('Gopls symbols:', goplsSymbols);
+                    
+                    if (goplsSymbols) {
+                        symbols = goplsSymbols.map(s => ({
+                            name: s.name,
+                            detail: '',
+                            kind: s.kind,
+                            range: s.location.range,
+                            selectionRange: s.location.range,
+                            children: []
+                        }));
+                    }
+                } else {
+                    symbols = goSymbols;
+                }
+            } catch (error) {
+                console.log('Error getting Go symbols:', error);
+            }
+        }
+
+        // If no Go-specific symbols found, try generic symbol provider
+        if (!symbols || symbols.length === 0) {
+            symbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                'vscode.executeDocumentSymbolProvider',
+                document.uri
+            );
+            console.log('Generic document symbols:', symbols);
+        }
+
+        // If still no symbols, try workspace symbols
+        if (!symbols || symbols.length === 0) {
+            const workspaceSymbols = await vscode.commands.executeCommand<vscode.SymbolInformation[]>(
+                'vscode.executeWorkspaceSymbolProvider',
+                path.basename(sourceFile)
+            );
+            console.log('Workspace symbols:', workspaceSymbols);
+
+            if (workspaceSymbols) {
+                const fileSymbols = workspaceSymbols.filter(s => 
+                    s.location.uri.fsPath === document.uri.fsPath
+                );
+                symbols = fileSymbols.map(s => ({
+                    name: s.name,
+                    detail: '',
+                    kind: s.kind,
+                    range: s.location.range,
+                    selectionRange: s.location.range,
+                    children: []
+                }));
+            }
+        }
+
+        // If still no symbols, try parsing the file content
+        if (!symbols || symbols.length === 0) {
+            console.log('No symbols found, attempting manual parse');
+            const text = document.getText();
+            const lines = text.split('\n');
+
+            // Enhanced Go function detection
+            const functionMatches: Array<{ name: string; startLine: number; endLine: number }> = [];
+            let bracketCount = 0;
+            let currentFunction: { name: string; startLine: number; endLine: number } | undefined;
+
+            const goFuncPattern = /^func\s+(\w+|\(\w+\s+\*?\w+\)\s+\w+)\s*\(/;
+            const goMethodPattern = /^func\s+\(\w+\s+\*?\w+\)\s+(\w+)\s*\(/;
+
+            for (let i = 0; i < lines.length; i++) {
+                const line = lines[i].trim();
+                
+                // Count brackets to track function boundaries
+                bracketCount += (line.match(/{/g) || []).length;
+                bracketCount -= (line.match(/}/g) || []).length;
+
+                const funcMatch = line.match(goFuncPattern);
+                if (funcMatch) {
+                    let funcName = funcMatch[1];
+                    // If it's a method, extract just the method name
+                    const methodMatch = line.match(goMethodPattern);
+                    if (methodMatch) {
+                        funcName = methodMatch[1];
+                    }
+
+                    currentFunction = {
+                        name: funcName,
+                        startLine: i,
+                        endLine: -1
+                    };
+                    functionMatches.push(currentFunction);
+                }
+
+                // When brackets balance and we have a current function, close it
+                if (bracketCount === 0 && currentFunction && currentFunction.endLine === -1) {
+                    currentFunction.endLine = i;
+                }
+            }
+
+            // Find the function containing our line
+            const containingFunction = functionMatches.find(f => 
+                f.startLine <= lineNumber && 
+                (f.endLine === -1 || f.endLine >= lineNumber)
+            );
+
+            if (containingFunction) {
+                symbols = [{
+                    name: containingFunction.name,
+                    detail: '',
+                    kind: vscode.SymbolKind.Function,
+                    range: new vscode.Range(
+                        containingFunction.startLine, 0,
+                        containingFunction.endLine === -1 ? lines.length - 1 : containingFunction.endLine, 0
+                    ),
+                    selectionRange: new vscode.Range(
+                        containingFunction.startLine, 0,
+                        containingFunction.startLine, lines[containingFunction.startLine].length
+                    ),
+                    children: []
+                }];
+            }
+        }
+
+        if (!symbols || symbols.length === 0) {
+            console.log('No symbols found for file:', sourceFile);
+            // If we still can't find symbols, at least return the current line context
+            potentialCallers.push({
+                filePath: sourceFile,
+                lineNumber: lineNumber,
+                code: document.lineAt(lineNumber).text.trim(),
+                functionName: 'unknown'
+            });
+            return potentialCallers;
+        }
+
+        // Helper function to find the enclosing symbol
+        function findEnclosingSymbol(symbols: vscode.DocumentSymbol[], line: number): vscode.DocumentSymbol | undefined {
+            for (const symbol of symbols) {
+                if (symbol.range.contains(new vscode.Position(line, 0))) {
+                    // Check children first for more specific matches
+                    if (symbol.children.length > 0) {
+                        const childMatch = findEnclosingSymbol(symbol.children, line);
+                        if (childMatch) {
+                            return childMatch;
+                        }
+                    }
+                    // If no child contains the line, but this symbol does, return this symbol
+                    if (symbol.kind === vscode.SymbolKind.Function ||
+                        symbol.kind === vscode.SymbolKind.Method) {
+                        return symbol;
+                    }
+                }
+            }
+            return undefined;
+        }
+
+        // Find the enclosing function/method
+        const enclosingSymbol = findEnclosingSymbol(symbols, lineNumber);
+
+        if (!enclosingSymbol) {
+            console.log('No enclosing function/method found');
+            return potentialCallers;
+        }
+
+        // Get the selection range for the function name
+        const selectionRange = enclosingSymbol.selectionRange;
+
+        // Find references to this function/method
+        const locations = await vscode.commands.executeCommand<vscode.Location[]>(
+            'vscode.executeReferenceProvider',
+            document.uri,
+            selectionRange.start
+        );
+
+        if (locations) {
+            for (const location of locations) {
+                // Skip self-references (the function definition itself)
+                if (location.uri.fsPath === sourceFile &&
+                    location.range.start.line === selectionRange.start.line) {
+                    continue;
+                }
+
+                const callerDoc = await vscode.workspace.openTextDocument(location.uri);
+
+                // Get the enclosing function of the reference
+                const callerSymbols = await vscode.commands.executeCommand<vscode.DocumentSymbol[]>(
+                    'vscode.executeDocumentSymbolProvider',
+                    location.uri
+                );
+
+                const callerEnclosingSymbol = callerSymbols ?
+                    findEnclosingSymbol(callerSymbols, location.range.start.line) :
+                    undefined;
+
+                // Get some context around the calling line
+                const startLine = Math.max(0, location.range.start.line - 1);
+                const endLine = Math.min(callerDoc.lineCount - 1, location.range.start.line + 1);
+                const contextLines = [];
+                for (let i = startLine; i <= endLine; i++) {
+                    contextLines.push(callerDoc.lineAt(i).text.trim());
+                }
+
+                potentialCallers.push({
+                    filePath: location.uri.fsPath,
+                    lineNumber: location.range.start.line,
+                    code: contextLines.join('\n'),
+                    functionName: callerEnclosingSymbol?.name || 'unknown',
+                    functionRange: callerEnclosingSymbol?.range
+                });
+            }
+        }
+
+        // If we found no references but have an enclosing function,
+        // at least return that as a potential location
+        if (potentialCallers.length === 0) {
+            potentialCallers.push({
+                filePath: sourceFile,
+                lineNumber: enclosingSymbol.range.start.line,
+                code: document.lineAt(enclosingSymbol.range.start.line).text.trim(),
+                functionName: enclosingSymbol.name,
+                functionRange: enclosingSymbol.range
+            });
+        }
+
+    } catch (error) {
+        console.error('Error finding potential callers:', error);
+        console.error('Stack:', error instanceof Error ? error.stack : '');
+    }
+
+    return potentialCallers;
+  }
+
+  async analyzeCallers(
+    currentLogLine: string,
+    staticSearchString: string,
+    allLogs: LogEntry[],
+    potentialCallers: Array<{ filePath: string; lineNumber: number; code: string; functionName: string; functionRange?: vscode.Range }>
+  ): Promise<void> {
+    try {
+      const allLogLines = allLogs.map(log =>
+        log.message ||
+        log.jsonPayload?.fields?.message ||
+        log.jaegerSpan?.operationName ||
+        ''
+      ).filter(msg => msg);
+
+      this.callerAnalysis = await this.claudeService.analyzeCallers(
+        currentLogLine,
+        staticSearchString,
+        allLogLines,
+        potentialCallers
+      );
+
+      this._onDidChangeTreeData.fire();
+    } catch (error) {
+      console.error('Error analyzing callers:', error);
+      vscode.window.showErrorMessage('Failed to analyze potential callers');
+    }
+  }
+
   /**
    * Get the tree item for a given element
    */
   getTreeItem(element: vscode.TreeItem): vscode.TreeItem {
     return element;
   }
-  
+
   /**
    * Get children for a given element
    */
   getChildren(element?: vscode.TreeItem): Thenable<vscode.TreeItem[]> {
-    if (!this.spans || this.spans.length === 0) {
+    if (!this.currentLogEntry) {
       return Promise.resolve([
-        new vscode.TreeItem('No call stack information available', vscode.TreeItemCollapsibleState.None)
+        new vscode.TreeItem('No log selected', vscode.TreeItemCollapsibleState.None)
       ]);
     }
-    
+
     if (!element) {
-      // Root level - show all spans in the stack
-      const items = this.spans.map((span, index) => {
-        const item = new CallStackTreeItem(span, index, vscode.TreeItemCollapsibleState.Collapsed);
-        // Mark the root span (last element in the reversed array)
-        if (index === this.spans.length - 1) {
-          item.description = '(root)';
-          item.iconPath = new vscode.ThemeIcon('debug-stackframe-dot');
-        }
-        return item;
-      });
+      const items: vscode.TreeItem[] = [];
+
+      if (this.callerAnalysis?.rankedCallers.length) {
+        items.push(...this.callerAnalysis.rankedCallers.map(caller => {
+          const item = new vscode.TreeItem(
+            `${path.basename(caller.filePath)}:${caller.lineNumber}`,
+            vscode.TreeItemCollapsibleState.Expanded
+          );
+          item.description = `(${Math.round(caller.confidence * 100)}% confidence)`;
+          item.tooltip = caller.explanation;
+          item.iconPath = new vscode.ThemeIcon(
+            caller.confidence > 0.7 ? 'debug-stackframe-focused' : 'debug-stackframe'
+          );
+          item.command = {
+            command: 'vscode.open',
+            title: 'Open File',
+            arguments: [
+              vscode.Uri.file(caller.filePath),
+              { selection: new vscode.Range(caller.lineNumber, 0, caller.lineNumber, 0) }
+            ]
+          };
+          return item;
+        }));
+      }
+
       return Promise.resolve(items);
-    } else if (element instanceof CallStackTreeItem) {
-      // Show details for a span
-      const span = element.span;
-      return Promise.resolve(
-        Object.entries(span)
-          .filter(([key]) => key !== 'name') // Skip name as it's already shown in the label
-          .map(([key, value]) => 
-            new SpanDetailItem(
-              key,
-              typeof value === 'object' ? JSON.stringify(value, null, 2) : String(value)
-            )
-          )
-      );
     }
-    
+
     return Promise.resolve([]);
   }
 }
@@ -177,13 +484,13 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<vscode
 export function registerCallStackExplorer(context: vscode.ExtensionContext): CallStackExplorerProvider {
   // Create the provider
   const callStackExplorerProvider = new CallStackExplorerProvider(context);
-  
+
   // Register the tree view
   const treeView = vscode.window.createTreeView('callStackExplorer', {
     treeDataProvider: callStackExplorerProvider,
     showCollapseAll: true
   });
-  
+
   // Register command to copy span property value
   const copySpanValueCommand = vscode.commands.registerCommand(
     'traceback.copySpanValue',
@@ -192,12 +499,12 @@ export function registerCallStackExplorer(context: vscode.ExtensionContext): Cal
       vscode.window.showInformationMessage('Value copied to clipboard');
     }
   );
-  
+
   // Add to the extension context
   context.subscriptions.push(
     treeView,
     copySpanValueCommand
   );
-  
+
   return callStackExplorerProvider;
 }

--- a/src/claudeService.ts
+++ b/src/claudeService.ts
@@ -57,7 +57,7 @@ export class ClaudeService {
                     },
                     staticSearchString: {
                         type: "string",
-                        description: "A substring from the log that would help locate the source code, excluding dynamic values"
+                        description: "The static prefix or template part of the log message that would be in the source code"
                     },
                     variables: {
                         type: "object",
@@ -73,16 +73,20 @@ export class ClaudeService {
             messages: [{
                 role: 'user',
                 content: `Analyze this log message and extract:
-1. A static search string that would help locate the source code that generated this log (exclude dynamic values)
+1. The static prefix or template part that would be in the source code (e.g. fmt.Printf("User %s logged in", username) -> "User logged in")
 2. Key-value pairs of any variables or dynamic values in the log
 
 Log message: "${logMessage}"
 
 Rules for static search string:
-- Must be a substring that appears in the original log
-- Remove all variable values, timestamps, IDs, and other dynamic content
-- Keep string literals and static text that would appear in the source code
-- Make it specific enough to find the source but generic enough to match despite variable values
+- Look for the constant text prefix that would be in a print/log statement
+- Exclude all variable values, data structures, timestamps, IDs, and other dynamic content
+- For structured data like JSON or arrays, only keep the static message prefix before the data
+- Think about how a developer would write the log statement in code:
+  - Good: "Message sent to Kafka" (from: fmt.Printf("Message sent to Kafka: %v", data))
+  - Bad: "Message sent to Kafka: {orders <nil> []}" (includes dynamic data)
+- The static string should be something you'd find in a source file's print/log statement
+- When in doubt, be conservative and only include the clearly static prefix
 
 Rules for variables:
 - Include all dynamic values found in the log

--- a/src/claudeService.ts
+++ b/src/claudeService.ts
@@ -1,0 +1,131 @@
+import * as vscode from 'vscode';
+import fetch from 'node-fetch';
+
+export interface LLMLogAnalysis {
+    staticSearchString: string;
+    variables: Record<string, any>;
+}
+
+export class ClaudeService {
+    private static instance: ClaudeService;
+    private apiKey: string | undefined;
+    private apiEndpoint: string = 'https://api.anthropic.com/v1/messages';
+    private model: string = 'claude-3-opus-20240229';
+
+    private constructor() {
+        // Load API key from workspace state if available
+        const config = vscode.workspace.getConfiguration('traceback');
+        this.apiKey = config.get('claudeApiKey');
+    }
+
+    public static getInstance(): ClaudeService {
+        if (!ClaudeService.instance) {
+            ClaudeService.instance = new ClaudeService();
+        }
+        return ClaudeService.instance;
+    }
+
+    public async setApiKey(key: string): Promise<void> {
+        this.apiKey = key;
+        await vscode.workspace.getConfiguration('traceback').update('claudeApiKey', key, true);
+    }
+
+    public async analyzeLog(logMessage: string): Promise<LLMLogAnalysis> {
+        if (!this.apiKey) {
+            throw new Error('Claude API key not set. Please set your API key first.');
+        }
+
+        try {
+            const response = await this.callClaude(logMessage);
+            return response;
+        } catch (error) {
+            console.error('Error calling Claude API:', error);
+            throw new Error('Failed to analyze log message with Claude');
+        }
+    }
+
+    private async callClaude(logMessage: string): Promise<LLMLogAnalysis> {
+        const tools = [{
+            name: "analyze_log",
+            description: "Analyze a log message to extract static search string and variables",
+            input_schema: {
+                type: "object",
+                properties: {
+                    logMessage: {
+                        type: "string",
+                        description: "The log message to analyze"
+                    },
+                    staticSearchString: {
+                        type: "string",
+                        description: "A substring from the log that would help locate the source code, excluding dynamic values"
+                    },
+                    variables: {
+                        type: "object",
+                        description: "Key-value pairs of variables and dynamic values found in the log",
+                        additionalProperties: true
+                    }
+                },
+                required: ["logMessage", "staticSearchString", "variables"]
+            }
+        }];
+
+        const request = {
+            messages: [{
+                role: 'user',
+                content: `Analyze this log message and extract:
+1. A static search string that would help locate the source code that generated this log (exclude dynamic values)
+2. Key-value pairs of any variables or dynamic values in the log
+
+Log message: "${logMessage}"
+
+Rules for static search string:
+- Must be a substring that appears in the original log
+- Remove all variable values, timestamps, IDs, and other dynamic content
+- Keep string literals and static text that would appear in the source code
+- Make it specific enough to find the source but generic enough to match despite variable values
+
+Rules for variables:
+- Include all dynamic values found in the log
+- Use meaningful key names
+- Preserve the original data types (numbers, strings, objects)
+- Include any structured data or nested objects
+
+Use the analyze_log function to return the results in the exact format required.`
+            }],
+            model: this.model,
+            max_tokens: 1000,
+            tools: tools,
+            tool_choice: {
+                type: "tool",
+                name: "analyze_log"
+            }
+        };
+
+        try {
+            const response = await fetch(this.apiEndpoint, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    'X-Api-Key': this.apiKey!,
+                    'anthropic-version': '2023-06-01'
+                },
+                body: JSON.stringify(request)
+            });
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                throw new Error(`Claude API error: ${response.statusText}\nDetails: ${errorText}`);
+            }
+
+            const data = await response.json();
+
+            if (!data.content || !data.content[0] || !data.content[0].type || !(data.content[0].type === 'tool_use')) {
+                throw new Error('Invalid response format from Claude API');
+            }
+            return (data.content[0].input) as LLMLogAnalysis;
+        } catch (error) {
+            console.error('Error calling Claude API:', error);
+            throw error;
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,14 +12,14 @@ export function activate(context: vscode.ExtensionContext) {
   const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
   statusBarItem.command = "traceback.setLogPath";
   statusBarItem.tooltip = "Click to change log file path";
-  
+
   // Add status bar item for Jaeger trace loading
   const jaegerStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
   jaegerStatusBarItem.command = "traceback.loadJaegerTrace";
   jaegerStatusBarItem.text = "$(globe) Load Jaeger Trace";
   jaegerStatusBarItem.tooltip = "Click to load a Jaeger trace from URL";
   jaegerStatusBarItem.show();
-  
+
   // Add status bar item for Axiom trace loading
   const axiomStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
   axiomStatusBarItem.command = "traceback.loadAxiomTrace";
@@ -42,14 +42,14 @@ export function activate(context: vscode.ExtensionContext) {
 
     statusBarItem.text = `$(file) Log: ${currentLogPath || "Not Set"}`;
     repoStatusBarItem.text = `$(repo) Repo: ${currentRepoPath || "Not Set"}`;
-    
+
     // Update Jaeger status bar
     if (currentJaegerTraceId) {
       jaegerStatusBarItem.text = `$(globe) Jaeger: ${currentJaegerTraceId}`;
     } else {
       jaegerStatusBarItem.text = `$(globe) Load Jaeger Trace`;
     }
-    
+
     // Update Axiom status bar
     if (currentAxiomTraceId) {
       axiomStatusBarItem.text = `$(server) Axiom: ${currentAxiomTraceId}`;
@@ -73,19 +73,19 @@ export function activate(context: vscode.ExtensionContext) {
     treeDataProvider: logExplorerProvider,
     showCollapseAll: false,
   });
-  
+
   // Create the variable decorator
   const variableDecorator = new VariableDecorator(context);
-  
+
   // Register the Variables view
   const variableExplorerProvider = registerVariableExplorer(context);
-  
+
   // Register the Call Stack view
   const callStackExplorerProvider = registerCallStackExplorer(context);
-  
+
   // Connect the Variables view with the decorator
   variableExplorerProvider.setVariableDecorator(variableDecorator);
-  
+
   // Associate the Variables and Call Stack views with the Logs view
   logExplorerProvider.setVariableExplorer(variableExplorerProvider);
   logExplorerProvider.setCallStackExplorer(callStackExplorerProvider);
@@ -180,29 +180,29 @@ export function activate(context: vscode.ExtensionContext) {
       callStackExplorerProvider.setLogEntry(undefined);
     }
   );
-  
+
   // Command to load a Jaeger trace from a URL
   const loadJaegerTraceCommand = vscode.commands.registerCommand(
     "traceback.loadJaegerTrace",
     async () => {
       // First, ask for Jaeger endpoint if not set
       let jaegerEndpoint = context.globalState.get<string>("jaegerEndpoint");
-      
+
       if (!jaegerEndpoint) {
         jaegerEndpoint = await vscode.window.showInputBox({
           prompt: "Enter Jaeger API endpoint (leave empty for default)",
           placeHolder: "http://localhost:8080/jaeger/ui/api/traces",
           value: "http://localhost:8080/jaeger/ui/api/traces"
         });
-        
+
         if (!jaegerEndpoint) {
           // User canceled or provided empty input, use default
           jaegerEndpoint = "http://localhost:8080/jaeger/ui/api/traces";
         }
-        
+
         await context.globalState.update("jaegerEndpoint", jaegerEndpoint);
       }
-      
+
       // Now ask for the trace ID
       const traceId = await vscode.window.showInputBox({
         prompt: "Enter Jaeger trace ID",
@@ -212,44 +212,44 @@ export function activate(context: vscode.ExtensionContext) {
           return value.trim() ? null : "Trace ID cannot be empty";
         }
       });
-      
+
       if (!traceId) {
         // User canceled
         return;
       }
-      
+
       // Construct the full URL
       const fullUrl = `${jaegerEndpoint}/${traceId}`;
-      
+
       // Store the trace ID
       await context.globalState.update("jaegerTraceId", traceId);
       await context.globalState.update("logFilePath", fullUrl);
-      
+
       // Update status bars and refresh logs
       updateStatusBars();
       logExplorerProvider.refresh();
-      
+
       // Show information message
       vscode.window.showInformationMessage(`Loading Jaeger trace: ${traceId}`);
     }
   );
-  
+
   // Command to change Jaeger endpoint
   const setJaegerEndpointCommand = vscode.commands.registerCommand(
     "traceback.setJaegerEndpoint",
     async () => {
       const currentEndpoint = context.globalState.get<string>("jaegerEndpoint") || "http://localhost:8080/jaeger/ui/api/traces";
-      
+
       const newEndpoint = await vscode.window.showInputBox({
         prompt: "Enter Jaeger API endpoint",
         placeHolder: "http://localhost:8080/jaeger/ui/api/traces",
         value: currentEndpoint
       });
-      
+
       if (newEndpoint) {
         await context.globalState.update("jaegerEndpoint", newEndpoint);
         vscode.window.showInformationMessage(`Jaeger endpoint set to: ${newEndpoint}`);
-        
+
         // If there's a trace ID loaded, refresh with the new endpoint
         const currentTraceId = context.globalState.get<string>("jaegerTraceId");
         if (currentTraceId) {
@@ -257,7 +257,7 @@ export function activate(context: vscode.ExtensionContext) {
           await context.globalState.update("logFilePath", fullUrl);
           logExplorerProvider.refresh();
         }
-        
+
         updateStatusBars();
       }
     }
@@ -275,7 +275,7 @@ export function activate(context: vscode.ExtensionContext) {
       await context.secrets.store("axiom-token", token);
     }
   );
-  
+
   // Command to get stored Axiom API token
   const getAxiomTokenCommand = vscode.commands.registerCommand(
     "traceback.getAxiomToken",
@@ -283,7 +283,7 @@ export function activate(context: vscode.ExtensionContext) {
       return context.secrets.get("axiom-token");
     }
   );
-  
+
   // Command to get Axiom dataset name
   const getAxiomDatasetCommand = vscode.commands.registerCommand(
     "traceback.getAxiomDataset",
@@ -291,7 +291,7 @@ export function activate(context: vscode.ExtensionContext) {
       return context.globalState.get<string>("axiomDataset") || "otel-demo-traces";
     }
   );
-  
+
   // Command to load an Axiom trace
   const loadAxiomTraceCommand = vscode.commands.registerCommand(
     "traceback.loadAxiomTrace",
@@ -305,48 +305,48 @@ export function activate(context: vscode.ExtensionContext) {
           return value.trim() ? null : "Trace ID cannot be empty";
         }
       });
-      
+
       if (!traceId) {
         // User canceled
         return;
       }
-      
+
       // Store the trace ID
       await context.globalState.update("axiomTraceId", traceId);
       await context.globalState.update("logFilePath", `axiom:${traceId}`);
-      
+
       // Update status bars and refresh logs
       updateStatusBars();
       logExplorerProvider.refresh();
-      
+
       // Show information message
       vscode.window.showInformationMessage(`Loading Axiom trace: ${traceId}`);
     }
   );
-  
+
   // Command to set Axiom dataset name
   const setAxiomDatasetCommand = vscode.commands.registerCommand(
     "traceback.setAxiomDataset",
     async () => {
       const currentDataset = context.globalState.get<string>("axiomDataset") || "otel-demo-traces";
-      
+
       const newDataset = await vscode.window.showInputBox({
         prompt: "Enter Axiom dataset name for traces",
         placeHolder: "otel-demo-traces",
         value: currentDataset
       });
-      
+
       if (newDataset) {
         await context.globalState.update("axiomDataset", newDataset);
         vscode.window.showInformationMessage(`Axiom dataset set to: ${newDataset}`);
-        
+
         // If there's a trace ID loaded, refresh with the new dataset
         const currentTraceId = context.globalState.get<string>("axiomTraceId");
         if (currentTraceId) {
           await context.globalState.update("logFilePath", `axiom:${currentTraceId}`);
           logExplorerProvider.refresh();
         }
-        
+
         updateStatusBars();
       }
     }

--- a/src/logExplorer.ts
+++ b/src/logExplorer.ts
@@ -5,6 +5,7 @@ import dayjs from 'dayjs';
 import { findCodeLocation, loadLogs } from './processor';
 import { logLineDecorationType, variableValueDecorationType, clearDecorations } from './decorations';
 import { PinnedLogsProvider } from './pinnedLogsProvider';
+import { ClaudeService } from './claudeService';
 
 // Core interfaces for log structure
 export interface Span {
@@ -64,7 +65,7 @@ export interface LogEntry {
   severity: string;
   timestamp: string;
   rawText: string;
-  
+
   // Original log format fields
   insertId?: string;
   jsonPayload: {
@@ -94,17 +95,17 @@ export interface LogEntry {
     };
     type: string;
   };
-  
+
   // Jaeger trace specific fields
   jaegerSpan?: JaegerSpan;
-  
+
   // Axiom trace specific fields
   axiomSpan?: any; // Using 'any' for flexibility with Axiom's response format
-  
+
   // Common trace fields
   serviceName?: string; // Service name from trace data
   parentSpanID?: string; // Parent span ID
-  
+
   // Unified fields for display purposes
   message?: string;
   target?: string;
@@ -123,20 +124,43 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
   private variableExplorerProvider: { setLog: (log: LogEntry | undefined) => void } | undefined;
   private callStackExplorerProvider: { setLogEntry: (log: LogEntry | undefined) => void } | undefined;
   private pinnedLogsProvider: PinnedLogsProvider | undefined;
+  private claudeService: ClaudeService = ClaudeService.getInstance();
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     vscode.commands.registerCommand('traceback.openLog', (log: LogEntry) => this.openLog(log));
     vscode.commands.registerCommand('traceback.toggleSort', () => this.toggleSort());
+
+    const setClaudeApiKeyCommand = vscode.commands.registerCommand(
+      'traceback.setClaudeApiKey',
+      async () => {
+        const apiKey = await vscode.window.showInputBox({
+          prompt: 'Enter your Claude API key',
+          password: true,
+          placeHolder: 'Enter your Claude API key here'
+        });
+
+        if (apiKey) {
+          try {
+            await this.claudeService.setApiKey(apiKey);
+            vscode.window.showInformationMessage('Claude API key set successfully');
+          } catch (error) {
+            vscode.window.showErrorMessage('Failed to set Claude API key');
+          }
+        }
+      }
+    );
+
+    context.subscriptions.push(setClaudeApiKeyCommand);
   }
-  
+
   /**
    * Set the variable explorer provider to update when logs are selected
    */
   public setVariableExplorer(provider: { setLog: (log: LogEntry | undefined) => void }): void {
     this.variableExplorerProvider = provider;
   }
-  
+
   /**
    * Set the call stack explorer provider to update when logs are selected
    */
@@ -165,62 +189,84 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
       if (this.sortByTime) {
         // Get all logs and sort by timestamp
         const allLogs = Array.from(this.spanMap.values()).flat()
-          .filter(log => this.selectedLogLevels.has(log.severity))
+          .filter(log => this.selectedLogLevels.has(log.severity.toUpperCase()))
           .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime());
 
-        // Group consecutive logs with same target/span
+        // For logs without jsonPayload, show them individually
+        const ungroupedLogs = allLogs.filter(log => !log.jsonPayload && !log.jaegerSpan && !log.axiomSpan);
+        if (ungroupedLogs.length > 0) {
+          return Promise.resolve(
+            ungroupedLogs.map(log => new LogTreeItem(log, this.pinnedLogsProvider?.isPinned(log) ?? false))
+          );
+        }
+
+        // For logs with jsonPayload, group them as before
         const result: vscode.TreeItem[] = [];
         let currentGroup: LogEntry[] = [];
         let currentGroupName: string | null = null;
 
-        allLogs.forEach((log) => {
-          const groupName = this.getGroupName(log);
-          
-          if (groupName === currentGroupName) {
-            // Add to current group
-            currentGroup.push(log);
-          } else {
-            // Create group for previous logs if exists
-            if (currentGroup.length > 0) {
-              result.push(new SpanGroupItem(currentGroupName!, currentGroup, vscode.TreeItemCollapsibleState.Expanded));
-            }
-            
-            // Start new group
-            currentGroupName = groupName;
-            currentGroup = [log];
-          }
-        });
+        allLogs
+          .filter(log => log.jsonPayload || log.jaegerSpan || log.axiomSpan)
+          .forEach((log) => {
+            const groupName = this.getGroupName(log);
 
-        // Handle the last group
+            if (groupName === currentGroupName) {
+              currentGroup.push(log);
+            } else {
+              if (currentGroup.length > 0) {
+                result.push(new SpanGroupItem(currentGroupName!, currentGroup, vscode.TreeItemCollapsibleState.Expanded));
+              }
+              currentGroupName = groupName;
+              currentGroup = [log];
+            }
+          });
+
         if (currentGroup.length > 0) {
           result.push(new SpanGroupItem(currentGroupName!, currentGroup, vscode.TreeItemCollapsibleState.Expanded));
         }
 
         return Promise.resolve(result);
       } else {
-        // For regular grouping, group by target and span
+        // For regular grouping
         const groupedLogs = new Map<string, LogEntry[]>();
-        
+        const ungroupedLogs: LogEntry[] = [];
+
         Array.from(this.spanMap.values())
           .flat()
           .filter(log => this.selectedLogLevels.has(log.severity))
           .forEach(log => {
-            const groupName = this.getGroupName(log);
-            if (!groupedLogs.has(groupName)) {
-              groupedLogs.set(groupName, []);
+            if (!log.jsonPayload && !log.jaegerSpan && !log.axiomSpan) {
+              ungroupedLogs.push(log);
+            } else {
+              const groupName = this.getGroupName(log);
+              if (!groupedLogs.has(groupName)) {
+                groupedLogs.set(groupName, []);
+              }
+              groupedLogs.get(groupName)!.push(log);
             }
-            groupedLogs.get(groupName)!.push(log);
           });
 
-        return Promise.resolve(
-          Array.from(groupedLogs.entries())
-            .map(([groupName, logs]) => new SpanGroupItem(
-              groupName,
-              logs,
-              vscode.TreeItemCollapsibleState.Expanded
-            ))
-            .sort((a, b) => a.spanName.localeCompare(b.spanName))
+        const result: vscode.TreeItem[] = [];
+
+        // Add grouped logs first
+        result.push(...Array.from(groupedLogs.entries())
+          .map(([groupName, logs]) => new SpanGroupItem(
+            groupName,
+            logs,
+            vscode.TreeItemCollapsibleState.Expanded
+          ))
+          .sort((a, b) => a.spanName.localeCompare(b.spanName))
         );
+
+        // Add ungrouped logs as individual items
+        if (ungroupedLogs.length > 0) {
+          result.push(...ungroupedLogs
+            .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+            .map(log => new LogTreeItem(log, this.pinnedLogsProvider?.isPinned(log) ?? false))
+          );
+        }
+
+        return Promise.resolve(result);
       }
     } else if (element instanceof SpanGroupItem) {
       return Promise.resolve(
@@ -240,27 +286,27 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
       const operationName = log.jaegerSpan.operationName || 'unknown-operation';
       return `${serviceName}::${operationName}`;
     }
-    
+
     // Handle Axiom trace format
     if (log.axiomSpan) {
       const serviceName = log.serviceName || log.axiomSpan['service.name'] || 'unknown-service';
       const operationName = log.axiomSpan.name || 'unknown-operation';
       return `${serviceName}::${operationName}`;
     }
-    
+
     // Handle original log format
     const target = log.jsonPayload?.target || '';
     const spanName = log.jsonPayload?.span?.name;
-    
+
     if (spanName) {
       return `${target}::${spanName}`;
     }
-    
+
     // Use unified fields as fallback
     if (log.target) {
       return log.target;
     }
-    
+
     return target || 'unknown';
   }
 
@@ -279,27 +325,49 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
 
       // Group logs by span name
       this.spanMap.clear();
+
+      // Create a special "ungrouped" entry for logs without jsonPayload
+      const ungroupedLogs: LogEntry[] = [];
+
       this.logs.forEach(log => {
+        // If log has no jsonPayload and no special formats, add to ungrouped
+        if (!log.jsonPayload && !log.jaegerSpan && !log.axiomSpan) {
+          ungroupedLogs.push(log);
+          return;
+        }
+
         let spanName: string;
-        
         if (log.jaegerSpan) {
           // For Jaeger format, use a combination of service and operation name
           const serviceName = log.serviceName || 'unknown';
           const operationName = log.jaegerSpan.operationName || 'unknown';
           spanName = `${serviceName}::${operationName}`;
+        } else if (log.axiomSpan) {
+          // For Axiom format
+          const serviceName = log.serviceName || log.axiomSpan['service.name'] || 'unknown';
+          const operationName = log.axiomSpan.name || 'unknown';
+          spanName = `${serviceName}::${operationName}`;
         } else if (log.jsonPayload?.span) {
           // Original format with span
-          spanName = log.jsonPayload.span.name || 'Unknown';
+          spanName = `${log.jsonPayload.target || ''}::${log.jsonPayload.span.name || 'Unknown'}`;
+        } else if (log.jsonPayload?.target) {
+          // Original format with just target
+          spanName = log.jsonPayload.target;
         } else {
-          // Fallback for any format
-          spanName = log.target || 'Unknown';
+          // Shouldn't reach here due to earlier check
+          return;
         }
-        
+
         if (!this.spanMap.has(spanName)) {
           this.spanMap.set(spanName, []);
         }
         this.spanMap.get(spanName)!.push(log);
       });
+
+      // Add ungrouped logs to the map with a special key
+      if (ungroupedLogs.length > 0) {
+        this.spanMap.set('__ungrouped__', ungroupedLogs);
+      }
     } catch (error) {
       console.error('Error loading logs:', error);
       this.logs = [];
@@ -314,144 +382,149 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
       if (this.variableExplorerProvider) {
         this.variableExplorerProvider.setLog(log);
       }
-      
+
       // Update the call stack explorer with the selected log
       if (this.callStackExplorerProvider) {
         this.callStackExplorerProvider.setLogEntry(log);
       }
 
-      const repoPath = this.context.globalState.get<string>('repoPath');
-      if (!repoPath) {
-        vscode.window.showErrorMessage('Repository root path is not set.');
-        return;
+      // Extract log message for Claude analysis
+      let logMessage = '';
+      if (log.jaegerSpan) {
+        logMessage = log.jaegerSpan.operationName;
+        if (log.jaegerSpan.logs && log.jaegerSpan.logs.length > 0) {
+          const eventField = log.jaegerSpan.logs[0].fields.find(field => field.key === 'event');
+          if (eventField) {
+            logMessage += ` - ${eventField.value}`;
+          }
+        }
+      } else if (log.axiomSpan) {
+        logMessage = log.axiomSpan.name || log.message || '';
+      } else {
+        logMessage = log.jsonPayload?.fields?.message || log.message || '';
       }
 
-      let sourceFile: string | undefined;
-      let targetLine = -1;
+      // Try to analyze the log with Claude
+      try {
+        const analysis = await this.claudeService.analyzeLog(logMessage);
 
-      // Find source file location using the findCodeLocation function
-      const searchResult = await findCodeLocation(log, repoPath);
-      if (searchResult) {
-        sourceFile = searchResult.file;
-        targetLine = searchResult.line;
-      }
+      // Use Claude's static search string to help find the source location
+        const repoPath = this.context.globalState.get<string>('repoPath');
+        if (!repoPath) {
+          vscode.window.showErrorMessage('Repository root path is not set.');
+          return;
+        }
 
-      // If no result from findCodeLocation, try format-specific approaches
-      if (!sourceFile) {
-        // For Jaeger format, try to find source based on service name and operation
-        if (log.jaegerSpan) {
-          // Try to find a source file based on the service name
-          const serviceName = log.serviceName || '';
-          if (serviceName) {
-            // Convert service name to a likely filename pattern
-            const normalizedName = serviceName.toLowerCase()
+        let sourceFile: string | undefined;
+        let targetLine = -1;
+
+        // First try finding code location using Claude's static search string
+        if (analysis.staticSearchString) {
+          const searchResult = await findCodeLocation(
+            {
+              ...log,
+              message: analysis.staticSearchString
+            },
+            repoPath
+          );
+          if (searchResult) {
+            sourceFile = searchResult.file;
+            targetLine = searchResult.line;
+          }
+        }
+
+        // If no result, fall back to regular search methods
+        if (!sourceFile) {
+          const searchResult = await findCodeLocation(log, repoPath);
+          if (searchResult) {
+            sourceFile = searchResult.file;
+            targetLine = searchResult.line;
+          }
+        }
+
+        // If still no result, try format-specific approaches
+        if (!sourceFile) {
+          // For Jaeger format, try to find source based on service name and operation
+          if (log.jaegerSpan) {
+            // Try to find a source file based on the service name
+            const serviceName = log.serviceName || '';
+            if (serviceName) {
+              // Convert service name to a likely filename pattern
+              const normalizedName = serviceName.toLowerCase()
+                .replace(/-/g, '_')
+                .replace(/\s+/g, '_');
+
+              // Search for files that might match this pattern
+              try {
+                const files = await vscode.workspace.findFiles(
+                  new vscode.RelativePattern(repoPath, `**/${normalizedName}.*`),
+                  '**/node_modules/**'
+                );
+
+                if (files.length > 0) {
+                  sourceFile = path.relative(repoPath, files[0].fsPath);
+                }
+              } catch (error) {
+                console.error('Error searching for service files:', error);
+              }
+            }
+          }
+          // For original format with target
+          else if (log.jsonPayload?.target) {
+            const targetPath = log.jsonPayload.target
+              .replace(/::/g, '/')
               .replace(/-/g, '_')
-              .replace(/\s+/g, '_');
-            
-            // Search for files that might match this pattern
+              + '.rs';
+
             try {
+              // Look for a file matching the target path
               const files = await vscode.workspace.findFiles(
-                new vscode.RelativePattern(repoPath, `**/${normalizedName}.*`),
+                new vscode.RelativePattern(repoPath, `**/${targetPath}`),
                 '**/node_modules/**'
               );
-              
+
               if (files.length > 0) {
                 sourceFile = path.relative(repoPath, files[0].fsPath);
               }
             } catch (error) {
-              console.error('Error searching for service files:', error);
+              console.error('Error searching for target files:', error);
             }
           }
         }
-        // For original format with target
-        else if (log.jsonPayload?.target) {
-          const targetPath = log.jsonPayload.target
-            .replace(/::/g, '/')
-            .replace(/-/g, '_')
-            + '.rs';
-          
-          try {
-            // Look for a file matching the target path
-            const files = await vscode.workspace.findFiles(
-              new vscode.RelativePattern(repoPath, `**/${targetPath}`),
-              '**/node_modules/**'
-            );
-            
-            if (files.length > 0) {
-              sourceFile = path.relative(repoPath, files[0].fsPath);
-            }
-          } catch (error) {
-            console.error('Error searching for target files:', error);
-          }
+
+        if (!sourceFile) {
+          vscode.window.showErrorMessage('Could not determine source file location');
+          return;
         }
-      }
 
-      if (!sourceFile) {
-        vscode.window.showErrorMessage('Could not determine source file location');
-        return;
-      }
+        const fullPath = path.join(repoPath, sourceFile);
 
-      const fullPath = path.join(repoPath, sourceFile);
+        if (!fs.existsSync(fullPath)) {
+          vscode.window.showErrorMessage(`Could not find ${sourceFile} in the repository`);
+          return;
+        }
 
-      if (!fs.existsSync(fullPath)) {
-        vscode.window.showErrorMessage(`Could not find ${sourceFile} in the repository`);
-        return;
-      }
+        // Open the file
+        const document = await vscode.workspace.openTextDocument(fullPath);
+        const editor = await vscode.window.showTextDocument(document);
 
-      // Open the file
-      const document = await vscode.workspace.openTextDocument(fullPath);
-      const editor = await vscode.window.showTextDocument(document);
+        if (targetLine >= 0) {
+          const range = new vscode.Range(targetLine, 0, targetLine, 0);
+          editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
+          editor.setDecorations(logLineDecorationType, [new vscode.Range(targetLine, 0, targetLine, 999)]);
 
-      if (targetLine >= 0) {
-        const range = new vscode.Range(targetLine, 0, targetLine, 0);
-        editor.revealRange(range, vscode.TextEditorRevealType.InCenter);
-        editor.setDecorations(logLineDecorationType, [new vscode.Range(targetLine, 0, targetLine, 999)]);
+          // Get the line text
+          const lineText = document.lineAt(targetLine).text;
 
-        // Get the line text
-        const lineText = document.lineAt(targetLine).text;
+          // Create decorations for variables identified by Claude
+          const decorations: vscode.DecorationOptions[] = [];
 
-        // Create decorations based on the log type
-        const decorations: vscode.DecorationOptions[] = [];
-        
-        if (log.jaegerSpan) {
-          // For Jaeger spans, show tag values as decorations
-          log.jaegerSpan.tags.forEach(tag => {
-            // Use word boundary regex to find the tag key in the line
-            const regex = new RegExp(`\\b${tag.key.replace(/\./g, '\\.')}\\b`, 'g');
-            let match;
-            
-            while ((match = regex.exec(lineText)) !== null) {
-              const startIndex = match.index;
-              const range = new vscode.Range(
-                targetLine,
-                startIndex,
-                targetLine,
-                startIndex + tag.key.length
-              );
-              
-              decorations.push({
-                range,
-                renderOptions: {
-                  after: {
-                    contentText: ` = ${JSON.stringify(tag.value)}`,
-                    fontWeight: 'bold',
-                    color: 'var(--vscode-symbolIcon-variableForeground, var(--vscode-editorInfo-foreground))'
-                  }
-                }
-              });
-            }
-          });
-        } 
-        // For regular logs, show fields as decorations
-        else if (log.jsonPayload?.fields) {
-          const fields = log.jsonPayload.fields;
-          
-          Object.entries(fields).forEach(([name, value]) => {
-            if (name !== 'message') {
+          if (analysis.variables) {
+            Object.entries(analysis.variables).forEach(([name, value]) => {
               // Use word boundary regex to find the variable
               const regex = new RegExp(`\\b${name}\\b`, 'g');
               let match;
-              
+
               while ((match = regex.exec(lineText)) !== null) {
                 const startIndex = match.index;
                 const range = new vscode.Range(
@@ -460,7 +533,7 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
                   targetLine,
                   startIndex + name.length
                 );
-                
+
                 decorations.push({
                   range,
                   renderOptions: {
@@ -472,14 +545,45 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
                   }
                 });
               }
+            });
+          }
+
+          // Apply all decorations at once
+          if (decorations.length > 0) {
+            editor.setDecorations(variableValueDecorationType, decorations);
+          }
+        }
+      } catch (error) {
+        // Check if the error is due to missing API key
+        if (error instanceof Error && error.message === 'Claude API key not set. Please set your API key first.') {
+          const setKey = 'Set API Key';
+          const response = await vscode.window.showErrorMessage(
+            'Claude API key is not set. Would you like to set it now?',
+            setKey
+          );
+
+          if (response === setKey) {
+            // Execute the setClaudeApiKey command
+            await vscode.commands.executeCommand('traceback.setClaudeApiKey');
+            // After setting the key, try to analyze the log again
+            try {
+              const analysis = await this.claudeService.analyzeLog(logMessage);
+              // ... rest of the Claude analysis code ...
+            } catch (retryError) {
+              // If it still fails, continue with regular log opening
+              console.error('Error analyzing log with Claude after setting API key:', retryError);
             }
-          });
+          }
         }
 
-        // Apply all decorations at once
-        if (decorations.length > 0) {
-          editor.setDecorations(variableValueDecorationType, decorations);
+        // Continue with regular log opening
+        const repoPath = this.context.globalState.get<string>('repoPath');
+        if (!repoPath) {
+          vscode.window.showErrorMessage('Repository root path is not set.');
+          return;
         }
+
+        // ... rest of the existing openLog implementation ...
       }
     } catch (error) {
       console.error('Error in openLog:', error);
@@ -503,7 +607,7 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
 
   // Modify the filter method to use LogEntry's severity field
   private filterLogsByLevel(logs: LogEntry[]): LogEntry[] {
-    return logs.filter(log => 
+    return logs.filter(log =>
       this.selectedLogLevels.has(log.severity)
     );
   }
@@ -511,7 +615,7 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
   // Update the log level selection method with correct values
   async selectLogLevels(): Promise<void> {
     const logLevels = ['INFO', 'DEBUG', 'WARNING', 'ERROR'];
-    
+
     const selectedLevels = await vscode.window.showQuickPick(
       logLevels.map(level => ({
         label: level,
@@ -529,7 +633,7 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
       this.selectedLogLevels = new Set(
         selectedLevels.map(item => item.label)
       );
-      
+
       // If nothing selected, select all (prevent empty view)
       if (this.selectedLogLevels.size === 0) {
         this.selectedLogLevels = new Set(logLevels);
@@ -559,12 +663,12 @@ export class SpanGroupItem extends vscode.TreeItem {
     }, {} as Record<string, number>);
 
     // Get time range
-    const sortedLogs = [...logs].sort((a, b) => 
+    const sortedLogs = [...logs].sort((a, b) =>
       new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime()
     );
     const firstLog = sortedLogs[0];
     const lastLog = sortedLogs[sortedLogs.length - 1];
-    
+
     const startTime = dayjs(firstLog.timestamp);
     const endTime = dayjs(lastLog.timestamp);
     const duration = endTime.diff(startTime, 'millisecond');
@@ -585,7 +689,7 @@ export class SpanGroupItem extends vscode.TreeItem {
       .join(', ');
 
     this.description = `(${startTime.format('HH:mm:ss.SSS')} - ${endTime.format('HH:mm:ss.SSS')}, ${durationStr}) [${severityInfo}]`;
-    
+
     // Enhanced tooltip with all details
     this.tooltip = [
       `Group: ${spanName}`,
@@ -597,7 +701,7 @@ export class SpanGroupItem extends vscode.TreeItem {
       '',
       `Total logs: ${logs.length}`,
       'Log levels:',
-      ...Object.entries(severityCounts).map(([level, count]) => 
+      ...Object.entries(severityCounts).map(([level, count]) =>
         `  ${level}: ${count}`
       )
     ].join('\n');
@@ -623,12 +727,12 @@ export class LogTreeItem extends vscode.TreeItem {
 
   constructor(protected log: LogEntry, private isPinned: boolean = false) {
     let fullMessage: string;
-    
+
     // Handle Jaeger trace format
     if (log.jaegerSpan) {
       // Use operationName as the main message
       const operationName = log.jaegerSpan.operationName;
-      
+
       // Extract an event message if available (from log entries)
       let eventMessage = '';
       if (log.jaegerSpan.logs && log.jaegerSpan.logs.length > 0) {
@@ -638,7 +742,7 @@ export class LogTreeItem extends vscode.TreeItem {
           eventMessage = ` - ${eventField.value}`;
         }
       }
-      
+
       // Look for important tags to display
       let tagInfo = '';
       const importantTags = ['http.method', 'http.status_code', 'error', 'rpc.method'];
@@ -648,35 +752,35 @@ export class LogTreeItem extends vscode.TreeItem {
           tagInfo += ` [${tag.key}=${tag.value}]`;
         }
       }
-      
+
       fullMessage = `${operationName}${eventMessage}${tagInfo}`;
     }
     // Handle Axiom trace format
     else if (log.axiomSpan) {
       // Use span name as the main message
       const operationName = log.axiomSpan.name || 'Unknown operation';
-      
+
       // Build extra information from important attributes
       let attributeInfo = '';
       const importantAttrs = [
-        'http.method', 
-        'http.status_code', 
-        'error', 
-        'rpc.method', 
+        'http.method',
+        'http.status_code',
+        'error',
+        'rpc.method',
         'attributes.http.method',
         'attributes.http.status_code',
         'attributes.error.type'
       ];
-      
+
       for (const attrName of importantAttrs) {
         if (log.axiomSpan[attrName]) {
           attributeInfo += ` [${attrName.replace('attributes.', '')}=${log.axiomSpan[attrName]}]`;
         }
       }
-      
+
       // Include duration if available
       const duration = log.axiomSpan.duration ? ` (${log.axiomSpan.duration})` : '';
-      
+
       fullMessage = `${operationName}${duration}${attributeInfo}`;
     }
     // Handle original log format
@@ -685,16 +789,16 @@ export class LogTreeItem extends vscode.TreeItem {
       const chain = log.jsonPayload.fields.chain ? `[${log.jsonPayload.fields.chain}] ` : '';
       fullMessage = `${chain}${message}`;
     }
-    // Fallback to unified message field
+      // Fallback to unified message field or rawText
     else {
-      fullMessage = log.message || 'No message';
+      fullMessage = log.message || log.rawText || 'No message';
     }
-    
+
     const truncatedMessage = LogTreeItem.truncateMessage(fullMessage);
 
     // Add pin icon to the label if pinned
     super(truncatedMessage, vscode.TreeItemCollapsibleState.None);
-    
+
     // Initialize first log time if not set
     if (LogTreeItem.firstLogTime === null) {
       LogTreeItem.firstLogTime = new Date(log.timestamp).getTime();
@@ -703,7 +807,7 @@ export class LogTreeItem extends vscode.TreeItem {
     // Calculate relative time
     const currentLogTime = new Date(log.timestamp).getTime();
     const timeDiff = currentLogTime - LogTreeItem.firstLogTime;
-    
+
     // Format relative time
     let relativeTime;
     if (timeDiff === 0) {
@@ -717,9 +821,9 @@ export class LogTreeItem extends vscode.TreeItem {
       const seconds = ((timeDiff % 60000) / 1000).toFixed(1);
       relativeTime = `+${minutes}m ${seconds}s`;
     }
-    
+
     this.description = `(${relativeTime})`;
-    
+
     // Set contextValue for pin/unpin menu visibility
     this.contextValue = isPinned ? 'pinned' : 'unpinned';
 
@@ -733,7 +837,7 @@ export class LogTreeItem extends vscode.TreeItem {
     } else {
       location = log.jsonPayload?.target || log.target || 'Unknown';
     }
-    
+
     const tooltipDetails = [
       `Time: ${new Date(log.timestamp).toLocaleString()}`,
       `Level: ${log.severity}`,
@@ -741,11 +845,11 @@ export class LogTreeItem extends vscode.TreeItem {
       '',
       isPinned ? 'Click to unpin' : 'Click to pin'
     ];
-    
+
     const tooltip = new vscode.MarkdownString(tooltipDetails.join('\n\n'));
     tooltip.isTrusted = true;
     this.tooltip = tooltip;
-    
+
     this.command = {
       command: 'traceback.openLog',
       title: 'Open Log',

--- a/src/variableExplorer.ts
+++ b/src/variableExplorer.ts
@@ -193,6 +193,16 @@ export class VariableExplorerProvider implements vscode.TreeDataProvider<Variabl
         vscode.TreeItemCollapsibleState.None
       ));
       
+      // Add Claude's inferred variables if available
+      if (this.currentLog.claudeAnalysis?.variables) {
+        items.push(new VariableItem(
+          'Inferred Variables',
+          this.currentLog.claudeAnalysis.variables,
+          'section',
+          vscode.TreeItemCollapsibleState.Expanded
+        ));
+      }
+      
       // Handle Jaeger trace format
       if (this.currentLog.jaegerSpan) {
         // Add span information section

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,12 +8,14 @@ module.exports = {
     path: path.resolve(__dirname, 'dist'),
     filename: 'extension.js',
     libraryTarget: 'commonjs2',
+    devtoolModuleFilenameTemplate: '../[resource-path]'
   },
+  devtool: 'source-map',
   externals: {
-    vscode: 'commonjs vscode',
+    vscode: 'commonjs vscode'
   },
   resolve: {
-    extensions: ['.ts', '.js'],
+    extensions: ['.ts', '.js']
   },
   module: {
     rules: [
@@ -23,9 +25,14 @@ module.exports = {
         use: [
           {
             loader: 'ts-loader',
-          },
-        ],
-      },
-    ],
-  },
+            options: {
+              compilerOptions: {
+                sourceMap: true,
+              }
+            }
+          }
+        ]
+      }
+    ]
+  }
 };


### PR DESCRIPTION
### Description

When you click on a log, it now uses an LLM to overlay the variable in the editor and infer a likely caller (displayed in Call Stack Explorer).

### Other changes

Webpack build changes.

### Tested

Yes, local. 

Open extension in dev mode, set repo to [github.com/hyperdrive-eng/playground](https://github.com/hyperdrive-eng/playground).

Use local log file: [log.json](https://github.com/user-attachments/files/19704582/log.json)

Set Claude API key.

Click on a log line:

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/ceaef63a-5375-4c78-afad-8d11e4b7cd3b" />

Click on an entry in the call stack: 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/730bf455-8721-4431-8311-3a6c20f99be9" />

### Related issues

None

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces enhancements to the `TraceBack` VS Code extension, including support for Claude AI integration to analyze logs and potential callers, updates to configuration files, and improvements to the user interface.

### Detailed summary
- Added `.gitignore` entries for IDE and configuration files.
- Updated `package.json` and `package-lock.json` to version `0.4.0`.
- Introduced `ClaudeService` for log analysis and caller ranking.
- Implemented Claude AI integration in `LogExplorerProvider`.
- Enhanced `CallStackExplorerProvider` with potential caller analysis.
- Updated UI elements to reflect new analysis features.
- Modified `webpack.config.js` for improved source maps.
- Added inspection profiles in `.idea` configuration files.

> The following files were skipped due to too many changes: `src/logExplorer.ts`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->