### PR TITLE
chore(explorers): delete detailed tooltip

### DIFF
--- a/src/callStackExplorer.ts
+++ b/src/callStackExplorer.ts
@@ -37,7 +37,6 @@ export class CallStackTreeItem extends vscode.TreeItem {
     );
 
     this.description = caller.confidence ? `(${Math.round(caller.confidence * 100)}% confidence)` : '';
-    this.tooltip = caller.explanation || caller.code;
     this.iconPath = new vscode.ThemeIcon(
       caller.confidence > 0.7 ? 'debug-stackframe-focused' : 'debug-stackframe'
     );

--- a/src/logExplorer.ts
+++ b/src/logExplorer.ts
@@ -842,21 +842,6 @@ export class SpanGroupItem extends vscode.TreeItem {
 
     this.description = `(${startTime.format('HH:mm:ss.SSS')} - ${endTime.format('HH:mm:ss.SSS')}, ${durationStr}) [${severityInfo}]`;
 
-    // Enhanced tooltip with all details
-    this.tooltip = [
-      `Group: ${spanName}`,
-      '',
-      'Time Range:',
-      `  Start: ${startTime.format('YYYY-MM-DD HH:mm:ss.SSS')}`,
-      `  End: ${endTime.format('YYYY-MM-DD HH:mm:ss.SSS')}`,
-      `  Duration: ${durationStr}`,
-      '',
-      `Total logs: ${logs.length}`,
-      'Log levels:',
-      ...Object.entries(severityCounts).map(([level, count]) =>
-        `  ${level}: ${count}`
-      )
-    ].join('\n');
 
     // Determine icon color based on severities present in logs
     if (severityCounts['ERROR'] && severityCounts['ERROR'] > 0) {
@@ -980,8 +965,6 @@ export class LogTreeItem extends vscode.TreeItem {
     // Set the icon based on severity
     this.iconPath = this.getIcon(log.severity);
 
-    // Use simpler tooltip format
-    this.tooltip = new vscode.MarkdownString(`**Timestamp:** ${log.timestamp}\n\n**Severity:** ${log.severity}\n\n**Target:** ${log.target || 'N/A'}\n\n\`\`\`\n${log.rawText}\n\`\`\``);
 
     this.command = {
       command: 'traceback.openLog',

--- a/src/variableExplorer.ts
+++ b/src/variableExplorer.ts
@@ -608,7 +608,6 @@ export function registerVariableExplorer(context: vscode.ExtensionContext): Vari
           <body>
             <h3>${escapeHtml(variableName)}</h3>
             <div class="value">${escapeHtml(stringValue)}</div>
-            <div class="escape-hint">Press 'Escape' to close this view</div>
           </body>
           </html>
         `;


### PR DESCRIPTION

### Description

- chore(logExplorer.ts): delete detailed tool tip on hover. It was too distracting.
- chore(callStackExplorer.ts) delete detailed tool tip on hover.

### Other changes

- chore(variableExplorer.ts): delete "esc" message. This nit was left from #12. 

### Tested

Yes, on playground logs and repo:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/4961c86b-b220-429f-a21c-c0ccbae63d5b" />

### Related issues

- closes [HYP-180: Info on hover too distracting in log explorer](https://linear.app/opensigma/issue/HYP-180/info-on-hover-too-distracting-in-log-explorer)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, all features work as usual.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR primarily focuses on simplifying tooltips and removing unnecessary UI elements in the `variableExplorer`, `callStackExplorer`, and `logExplorer` components, enhancing the user experience by streamlining information presentation.

### Detailed summary
- Removed the escape hint div in `src/variableExplorer.ts`.
- Simplified the tooltip in `src/callStackExplorer.ts` to only show confidence.
- Updated the tooltip in `src/logExplorer.ts` to a simpler format, removing detailed log information and using a more concise representation.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->