### PR TITLE
refactor(jaeger): deletes all Jaeger related code

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "repository": {
     "type": "git",
     "url": "https://github.com/hyperdrive-eng/traceback.git"

--- a/src/callStackExplorer.ts
+++ b/src/callStackExplorer.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { LogEntry, Span, JaegerSpan } from './logExplorer';
+import { LogEntry, Span } from './logExplorer';
 import { CallerAnalysis } from './claudeService';
 import { ClaudeService } from './claudeService';
 import * as path from 'path';
@@ -414,7 +414,6 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<CallSt
       const allLogLines = allLogs.map(log =>
         log.message ||
         log.jsonPayload?.fields?.message ||
-        log.jaegerSpan?.operationName ||
         ''
       ).filter(msg => msg);
 

--- a/src/variableExplorer.ts
+++ b/src/variableExplorer.ts
@@ -222,7 +222,6 @@ export class VariableExplorerProvider implements vscode.TreeDataProvider<Variabl
       // Add a header showing the log message
       const headerMessage = this.currentLog.message || 
                             (this.currentLog.jsonPayload?.fields?.message) || 
-                            (this.currentLog.jaegerSpan?.operationName) ||
                             'Log Entry';
       
       // For the header, we'll use the entire log object as the value for inspection
@@ -249,112 +248,58 @@ export class VariableExplorerProvider implements vscode.TreeDataProvider<Variabl
         ));
       }
       
-      // Handle Jaeger trace format
-      if (this.currentLog.jaegerSpan) {
-        // Add span information section
+      // Handle log format
+      // Add common sections
+      
+      // Fields section
+      const fields = this.currentLog.jsonPayload?.fields;
+      if (fields && Object.keys(fields).length > 0) {
+        items.push(new VariableItem(
+          'Fields',
+          fields,
+          'Fields', // Use 'Fields' as specific type to filter message in children
+          vscode.TreeItemCollapsibleState.Expanded
+        ));
+      }
+      
+      // Span information
+      if (this.currentLog.jsonPayload?.span) {
         items.push(new VariableItem(
           'Span',
-          this.currentLog.jaegerSpan,
+          this.currentLog.jsonPayload.span,
           'section',
           vscode.TreeItemCollapsibleState.Expanded
         ));
-        
-        // Extract tags into their own section for easier viewing
-        if (this.currentLog.jaegerSpan.tags && this.currentLog.jaegerSpan.tags.length > 0) {
-          // Convert tags array to an object for easier viewing
-          const tagsObject: Record<string, any> = {};
-          for (const tag of this.currentLog.jaegerSpan.tags) {
-            tagsObject[tag.key] = tag.value;
-          }
-          
-          items.push(new VariableItem(
-            'Tags',
-            tagsObject,
-            'section',
-            vscode.TreeItemCollapsibleState.Expanded
-          ));
-        }
-        
-        // Extract span logs into their own section
-        if (this.currentLog.jaegerSpan.logs && this.currentLog.jaegerSpan.logs.length > 0) {
-          items.push(new VariableItem(
-            'Span Logs',
-            this.currentLog.jaegerSpan.logs,
-            'section',
-            vscode.TreeItemCollapsibleState.Collapsed
-          ));
-        }
-        
-        // Add process information if available
-        if (this.currentLog.serviceName) {
-          const serviceInfo = {
-            name: this.currentLog.serviceName,
-            spanId: this.currentLog.jaegerSpan.spanID,
-            parentSpanId: this.currentLog.parentSpanID
-          };
-          
-          items.push(new VariableItem(
-            'Service',
-            serviceInfo,
-            'section',
-            vscode.TreeItemCollapsibleState.Collapsed
-          ));
-        }
       }
-      // Handle original log format
-      else {
-        // Add common sections
-        
-        // Fields section
-        const fields = this.currentLog.jsonPayload?.fields;
-        if (fields && Object.keys(fields).length > 0) {
-          items.push(new VariableItem(
-            'Fields',
-            fields,
-            'Fields', // Use 'Fields' as specific type to filter message in children
-            vscode.TreeItemCollapsibleState.Expanded
-          ));
-        }
-        
-        // Span information
-        if (this.currentLog.jsonPayload?.span) {
-          items.push(new VariableItem(
-            'Span',
-            this.currentLog.jsonPayload.span,
-            'section',
-            vscode.TreeItemCollapsibleState.Expanded
-          ));
-        }
-        
-        // Multiple spans array
-        if (this.currentLog.jsonPayload?.spans && this.currentLog.jsonPayload.spans.length > 0) {
-          items.push(new VariableItem(
-            'Spans',
-            this.currentLog.jsonPayload.spans,
-            'section',
-            vscode.TreeItemCollapsibleState.Collapsed
-          ));
-        }
-        
-        // Labels
-        if (this.currentLog.labels && Object.keys(this.currentLog.labels).length > 0) {
-          items.push(new VariableItem(
-            'Labels',
-            this.currentLog.labels,
-            'section',
-            vscode.TreeItemCollapsibleState.Collapsed
-          ));
-        }
-        
-        // Resource information
-        if (this.currentLog.resource) {
-          items.push(new VariableItem(
-            'Resource',
-            this.currentLog.resource,
-            'section',
-            vscode.TreeItemCollapsibleState.Collapsed
-          ));
-        }
+      
+      // Multiple spans array
+      if (this.currentLog.jsonPayload?.spans && this.currentLog.jsonPayload.spans.length > 0) {
+        items.push(new VariableItem(
+          'Spans',
+          this.currentLog.jsonPayload.spans,
+          'section',
+          vscode.TreeItemCollapsibleState.Collapsed
+        ));
+      }
+      
+      // Labels
+      if (this.currentLog.labels && Object.keys(this.currentLog.labels).length > 0) {
+        items.push(new VariableItem(
+          'Labels',
+          this.currentLog.labels,
+          'section',
+          vscode.TreeItemCollapsibleState.Collapsed
+        ));
+      }
+      
+      // Resource information
+      if (this.currentLog.resource) {
+        items.push(new VariableItem(
+          'Resource',
+          this.currentLog.resource,
+          'section',
+          vscode.TreeItemCollapsibleState.Collapsed
+        ));
       }
       
       // Basic log metadata for all log types


### PR DESCRIPTION
### Description

1. refactor(jaeger): deletes all Jaeger related code. We don't support Jaeger traces pulled via the Jaeger API for now. We are focusing on logs. 

### Other changes

1. chore(package.json): bumps extension version to 0.4.5, we haven't bumped it in the past couple of PRs 
    #14 
    #12

### Tested

Yes, with playground logs and repo:

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/bc8f4256-6bde-4cc2-ba21-eea176e9088d" />

Variable inspect works

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/c25d4c37-4b19-4c71-a3ed-2ce7cba7058c" />

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/868dad4e-ce97-489c-ae1c-fdc302acf20b" />

Settings page, loading logs from file works: 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/f49d3397-01be-4fea-8620-7fb541b86a92" />

### Related issues

- closes [HYP-175: Delete Jaeger commands or add them to the settings page](https://linear.app/opensigma/issue/HYP-175/delete-jaeger-commands-or-add-them-to-the-settings-page)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  4. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

No, deleted Jaeger code, we don't support importing Jaeger traces from the Jaeger API using a trace ID anymore.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on removing the handling of `Jaeger` traces from the codebase, simplifying the log processing and related commands, and updating the log entry structure accordingly.

### Detailed summary
- Removed `JaegerSpan` and `JaegerTrace` interfaces from `logExplorer.ts`.
- Eliminated Jaeger-specific fields from `LogEntry`.
- Removed Jaeger trace handling in `callStackExplorer.ts`, `variableExplorer.ts`, and `logExplorer.ts`.
- Deleted commands related to loading and setting Jaeger trace and endpoint in `extension.ts`.
- Updated filtering and processing logic to exclude Jaeger spans in `LogExplorerProvider`.
- Adjusted log parsing and entry creation to focus solely on Axiom spans.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->