### PR TITLE
feat(skip tests): Skip test directories during caller analysis

### DIFF
--- a/src/callStackExplorer.ts
+++ b/src/callStackExplorer.ts
@@ -69,6 +69,21 @@ interface CallStackCache {
 }
 
 /**
+ * Helper function to check if a file path is a test file
+ */
+function isTestPath(filePath: string): boolean {
+  const normalizedPath = filePath.toLowerCase();
+  return normalizedPath.includes('/test/') ||
+         normalizedPath.includes('/tests/') ||
+         normalizedPath.includes('/__tests__/') ||
+         normalizedPath.includes('/__test__/') ||
+         normalizedPath.includes('.test.') ||
+         normalizedPath.includes('.spec.') ||
+         normalizedPath.includes('_test.') ||
+         normalizedPath.includes('_spec.');
+}
+
+/**
  * TreeItem for call stack entries in the Call Stack Explorer
  */
 export class CallStackTreeItem extends vscode.TreeItem {
@@ -334,6 +349,11 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<CallSt
 
             if (locations) {
                 for (const location of locations) {
+                    // Skip test files
+                    if (isTestPath(location.uri.fsPath)) {
+                        continue;
+                    }
+
                     // Skip self-references (the function definition itself)
                     if (location.uri.fsPath === sourceFile &&
                         location.range.start.line === selectionRange.start.line) {


### PR DESCRIPTION
### Description

Skip any files within test directories while showing call stack analysis.

### Tested
Since the change is minimal, just tested the call stack debugging flow.

### Related issues

- closes [HYP-159: Exclude cache and test directories](https://linear.app/opensigma/issue/HYP-159/exclude-cache-and-test-directories)


### Backwards compatibility

_Brief explanation of why these changes are/are not backwards compatible._

### Documentation

_The set of community facing docs that have been added/modified because of this change_


<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces a helper function to filter out test files from the call stack entries in the `CallStackExplorerProvider`. This ensures that test files are not processed when displaying call stack information.

### Detailed summary
- Added a new function `isTestPath` to check if a file path is a test file.
- Implemented a check within the `CallStackExplorerProvider` to skip processing for test files by using `isTestPath`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->