### PR TITLE
chore(build.yaml): add VS Code publish step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,3 +40,9 @@ jobs:
         with:
           files: "*.vsix"
           tag_name: ${{ github.event.inputs.version }}
+          
+      # Publish to VS Code Marketplace
+      - name: Publish to VS Code Marketplace
+        run: npx vsce publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
### Description

1. chore(.github/workflows/build.yaml): adds VS Code publish step

### Other changes

None.

### Tested

No, I'll test once I merge this PR. 

### Related issues

- closes [HYP-187: VS Code publish workflow](https://linear.app/opensigma/issue/HYP-187/vs-code-publish-workflow)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes. 

### Documentation

I set a VS Code marketplace [personal access token](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#get-a-personal-access-token) as a Github secret:

<img width="797" alt="image" src="https://github.com/user-attachments/assets/7e2818d2-7e5b-4f73-a847-53dd955df0e6" />

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new step to the GitHub Actions workflow for publishing a Visual Studio Code extension to the VS Code Marketplace.

### Detailed summary
- Added a comment indicating the purpose of the new step: `# Publish to VS Code Marketplace`
- Introduced a new step named `Publish to VS Code Marketplace`
- Included a command to run: `npx vsce publish`
- Set an environment variable `VSCE_PAT` using a secret from GitHub Actions

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->