### PR TITLE
docs(README): adds gif in Demo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,13 @@
 
 A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.
 
+## Demo
+
+![TraceBack demo (v0 4 7)](https://github.com/user-attachments/assets/07701ce5-54a0-42e4-ad6e-a6e77238b6d4)
+
 ## Quick Start
 
-1. [Install extension](https://marketplace.visualstudio.com/items/?itemName=hyperdrive-eng.traceback)
+1. Install the [extension](https://marketplace.visualstudio.com/items/?itemName=hyperdrive-eng.traceback)
 
 1. Import logs
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

1. docs(README): adds gif in Demo section

### Other changes

1. chore(package.json): bumps version to 0.4.8
2. docs(README): nit small word change in Quick Start section

### Tested

Yes, preview in Github: 

<img width="1088" alt="image" src="https://github.com/user-attachments/assets/8ec4055f-f624-46f1-a617-41c0605f5e22" />

### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  3. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, docs-only change.

### Documentation

None


<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a demo section to the `README.md` for the VS Code extension, enhancing the documentation with a visual representation of the extension's functionality.

### Detailed summary
- Added a new section titled `## Demo` to showcase a demo image for the extension.
- Updated the installation instructions by modifying the phrasing for clarity, changing "1. [Install extension]" to "1. Install the [extension]".

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->