### PR TITLE
docs(README): add Claude API in Usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ A VS Code extension that brings telemetry data (traces, logs, and metrics) into 
 
     <img width="376" alt="image" src="https://github.com/user-attachments/assets/681d10f6-d4c3-4478-9bf4-7790b272a050" />
 
+1. Set Claude API Key
+
+    <img width="609" alt="image" src="https://github.com/user-attachments/assets/da51c800-1393-47e8-b5de-32026ac23938" />
+
 1. Click on a log
 
    <img width="1465" alt="image" src="https://github.com/user-attachments/assets/98a0dad4-0164-4034-a064-343ff36a38aa" />

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

1. docs(README): add Claude API in Usage section

### Other changes

1. chore(package.json): bump version to 0.4.9

### Tested

No, docs-only.

### Related issues

- closes [HYP-189: Add API key instruction to README](https://linear.app/opensigma/issue/HYP-189/add-api-key-instruction-to-readme)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  2. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, docs-only change.

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the version of the `TraceBack` VS Code extension and adds new content to the `README.md` file, including instructions for setting up the Claude API Key.

### Detailed summary
- Updated `version` from `0.4.8` to `0.4.9` in `package.json`.
- Added a new section in `README.md` for setting the Claude API Key.
- Included an image related to the Claude API Key setup in `README.md`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->