### PR TITLE
feat(code search): exclude log severity levels from search strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

1. feat(claudeService.ts): add instruction for log level

    - Modified the prompt to explicitly tell Claude to avoid including log level indicators like [INFO] in the static search string
    - Added a cleanup step to remove log level indicators from the static search string if Claude still includes them
    - Updated examples to show the desired clean output format

2. feat(processor.ts): delete log level in search

   - Added processing in findCodeLocation to clean up search strings by removing log level indicators like [INFO] and timestamps
    - Modified calculateMatchScore to clean the search content by removing log level indicators
    - Removed the penalty for log level indicators in the code since we're now cleaning them from search strings

### Other changes

1. chore(package.json): bumps version to `0.4.10`

### Tested

**Before**: playground repo and `shipping.log`

![image](https://github.com/user-attachments/assets/4cc18fc7-50eb-40f3-b77f-57b0ba9d24ab)

**After**: playground repo and `shipping.log`

https://github.com/user-attachments/assets/060cf6bc-c042-46aa-a539-7f96945d3198

Not much better in Hyperlane repo, but still finds code location: 

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/2532486e-600d-4818-bf06-abc52820f1a0" />

### Related issues

- closes [HYP-190: Extension doesn't work well on Hyperlane demo and OTEL Rust code](https://linear.app/opensigma/issue/HYP-190/extension-doesnt-work-well-on-hyperlane-demo-and-otel-rust-code)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  3. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes.

Tested in Golang directory with `checkout.log`

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/af02a01d-7739-451b-a90c-f5ffc7a4bfd6" />

### Documentation

None.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the logging functionality in the `claudeService.ts` and `processor.ts` files by cleaning up log messages. It removes log level indicators and timestamps from search strings, enhancing the accuracy of log analysis.

### Detailed summary
- Updated `version` in `package.json` from `0.4.9` to `0.4.10`.
- Enhanced static string extraction rules in `claudeService.ts`.
- Added logic to remove log level indicators and timestamps from search content.
- Improved error handling for empty searchable content.
- Refined match scoring in `calculateMatchScore` function.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->