### PR TITLE
feat(parsing): parse logs using regex returned by LLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules
 *.log
 .vscode-test/
 *.vsix
+
+# JetBrains
+.idea/

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",


### PR DESCRIPTION
### Description

1. feat(parsing): implements a new feature that uses Claude LLM to generate regex patterns for parsing log lines.

### Details

1. Enhanced ClaudeService:
    - Added a new method generateLogParsingRegex that takes sample logs and returns regex patterns
    - Configured to use Claude Haiku for cost efficiency and performance
    - Structured the API call to return named capture groups and extraction mappings
2. RegexLogParser Class:
    - Collects sample logs during the initial parsing attempt
    - Sends samples to the Claude API to generate regex patterns
    - Uses the generated patterns to parse log lines
    - Falls back to heuristic parsing for any unmatched lines
3. Integration with Existing System:
    - Updated the ExtensibleLogParser to include our new RegexLogParser
    - Positioned it in a way that ensures all logs are processed correctly
    - Maintained compatibility with existing JSON and plaintext parsers

### Other changes

1. chore(package.json): bump version to `0.4.12`
1. chore(gitignore): exclude `.idea/` from JetBrains IDEs

### Tested

Yes

- [x] Tested against [playground logs](https://github.com/hyperdrive-eng/playground/tree/main/logs)
- [x] Tested against [boomerang logs](https://github.com/jondo2010/boomerang)

#### `shipping.log` (Rust)

Parsing and code search works

![image](https://github.com/user-attachments/assets/c2a911f6-71fd-48e9-9106-448b638a8d07)

But, variable overlay is sometimes missing ([TraceBack](https://linear.app/opensigma/project/traceback-77da154ef3b7))

![image](https://github.com/user-attachments/assets/ed616d9a-183b-4fc1-af63-e2faddfa2daf)

#### `email.log` (Ruby)

![image](https://github.com/user-attachments/assets/10138c19-5c69-4c14-aec8-3f25923d75e7)

But, not sorted correctly ([HYP-198: Logs are not sorted in order they appear in log file](https://linear.app/opensigma/issue/HYP-198/logs-are-not-sorted-in-order-they-appear-in-log-file))

#### `fraud-detection.log` (Kotlin)

Before

![image](https://github.com/user-attachments/assets/88a7e30e-67ca-4460-949c-c78047a11bdd)

After

![image](https://github.com/user-attachments/assets/d5e5ad6c-6768-4921-be71-16ce2f064f4f)

Parsing works, but code search has bug ([HYP-205: Code search shows wrong file (should be Kotlin)](https://linear.app/opensigma/issue/HYP-205/code-search-shows-wrong-file-should-be-kotlin))

#### `recommendation.log` (Python)

Before: 

![image](https://github.com/user-attachments/assets/7ad23674-8693-47f9-835c-9b06b257e7c8)

After: 

![image](https://github.com/user-attachments/assets/a3f33bda-01ab-4d87-8b27-48c85cf20865)

Call stack only show one entry vs duplicate 4x, but still not displaying `prod_list` array in code ([HYP-200: Python array in log is not displayed in code](https://linear.app/opensigma/issue/HYP-200/python-array-in-log-is-not-displayed-in-code))

#### `accounting.log` (C#)

Parses correctly, but code search has bug ([HYP-198: Logs are not sorted in order they appear in log file](https://linear.app/opensigma/issue/HYP-198/logs-are-not-sorted-in-order-they-appear-in-log-file))

![image](https://github.com/user-attachments/assets/396f1e4b-41fa-4e1b-8cbf-865ab3c9e89d)

#### `ad.log` (Java)

Parsed correctly, but code search has bug ([HYP-206: Code search worked but doesn't highlight log line](https://linear.app/opensigma/issue/HYP-206/code-search-worked-but-doesnt-highlight-log-line))

![image](https://github.com/user-attachments/assets/718ab630-136c-44ac-8ce7-738e6d08616d)

#### `cart.log` (C#)

Parses correctly: 

![image](https://github.com/user-attachments/assets/e0f91218-cc24-411b-a15f-2aa040f3418c)

#### `checkout.log` (Go)

Parses correctly: 

![image](https://github.com/user-attachments/assets/ebd5104a-419b-4762-807b-547ff4bea43e)

![image](https://github.com/user-attachments/assets/39706f55-61fc-4d68-9a0d-5cfed6db69ab)

#### `payment.log` (JavaScript)

Parses correctly, but code search is flaky ([HYP-207: Code search is flaky (JS)](https://linear.app/opensigma/issue/HYP-207/code-search-is-flaky-js))

![image](https://github.com/user-attachments/assets/85b7e183-5564-418b-9be8-da67590167de)

#### `product-catalog.log` (Go)

Parses correctly, but code search is incorrect ([HYP-208: Code search fails (Go)](https://linear.app/opensigma/issue/HYP-208/code-search-fails-go) and [HYP-209: Call stack is incorrect (Go)](https://linear.app/opensigma/issue/HYP-209/call-stack-is-incorrect-go))

![image](https://github.com/user-attachments/assets/b4047bb1-e2d9-4595-9877-578e2520f54f)

#### `boomerang.log` (Rust)

Parses correctly and code search works:

![image](https://github.com/user-attachments/assets/9bfcbdaa-d617-4cfc-b0df-efdb5e838254)

![image](https://github.com/user-attachments/assets/24dccc6b-a512-4018-8f7f-cf616996b91f)

`debug` logs of this type parse correctly, but code search fails as expected: [HYP-212: Code search fails for `debug` logs (Boomerang)](https://linear.app/opensigma/issue/HYP-212/code-search-fails-for-debug-logs-boomerang)

Turns out that's ok, because the log doesn't have a searchable string. Not a regression.

```
2025-04-19T17:49:01.303607Z DEBUG event_loop:next{tag=[950ms+18446744073709551615]}: boomerang_runtime::sched: Processing event=L[tag=[1s+0],terminal=true]
```

![image](https://github.com/user-attachments/assets/536e062f-66d6-49ed-9f37-3bc06fd055fa)
 
Parsing and code search works: 

![image](https://github.com/user-attachments/assets/4f218c11-c6ca-4f72-83ae-2e9c4fefe528)

### Related issues

- closes [HYP-201: Parse log using regex with LLM](https://linear.app/opensigma/issue/HYP-201/parse-log-using-regex-with-llm)
- closes [HYP-196: Kotlin `fraud-detection.log` are not parsed correctly](https://linear.app/opensigma/issue/HYP-196/kotlin-fraud-detectionlog-are-not-parsed-correctly)
- closes [HYP-199: Call stack shows 4x the same line number with different confidence](https://linear.app/opensigma/issue/HYP-199/call-stack-shows-4x-the-same-line-number-with-different-confidence)
- closes [HYP-197: No code location found for JavaScript `payment` microservice logs](https://linear.app/opensigma/issue/HYP-197/no-code-location-found-for-javascript-payment-microservice-logs)

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  3. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, tested regressions above. 

### Documentation

TraceBack now includes an AI-powered log parsing system that uses Anthropic's Claude API to dynamically generate regex patterns for parsing log lines from various sources.

#### How It Works

1. The system collects sample log lines from your logs
2. It sends these samples to Claude (Haiku model) with a prompt to generate regex patterns
4. Claude analyzes the log format and returns regex patterns with named capture groups
5. The parser uses these patterns to parse each log line into a standardized LogEntry interface
6. This parsed information is used to improve code search and variable highlighting

#### How to Use

The system works automatically when you import logs. No special configuration is needed. The parsing process:

1. First attempts to parse logs as JSON
2. If not JSON, tries the AI-generated regex patterns
3. Falls back to heuristic parsing if no patterns match

#### Example Log Formats Supported

```
accounting  | Accounting service started
2025-04-11 12:35:57 - oteldemo.AdService - Ad service starting. trace_id= span_id= trace_flags=
2025-04-11T12:36:39.507327138Z INFO [PlaceOrder] user_id="9d7e2a1c-16d1-11f0-9eeb-0242ac120019" user_currency="USD"
172.18.0.21 - - [11/Apr/2025:12:37:55 +0000] "POST /send_order_confirmation HTTP/1.1" 200 - 0.0059
[2025-04-11 12:35:59.504][8][info][main] [source/server/server.cc:430] envoy.http.cache: envoy.extensions.http.cache.file_system_http_cache
{"level":"info","time":1744375125087,"trace_id":"be42ce7539882148d9e9226a90d9bd69","service.name":"payment","msg":"Charge request received."}
12:38:45 [INFO] Tracking ID Created: 7b73043a-c2ee-4471-ac0e-9b25af58afb0
```

#### Implementation Details

The feature consists of several components:

1. **ClaudeService**: Makes API calls to Claude to generate regex patterns
2. **RegexLogParser**: Uses the patterns to parse log lines
3. **LogEntry Interface**: Standardized representation of parsed log data

##### LogEntry Interface

```typescript
interface LogEntry {
  // Core fields
  severity: string;         // Log level (INFO, DEBUG, ERROR, etc.)
  timestamp: string;        // Timestamp in ISO format
  rawText: string;          // Original log line
  message: string;          // Main log message
  
  // Service identification
  serviceName?: string;     // Name of the service generating the log
  target?: string;          // Alternative name for the service
  
  // Additional data
  jsonPayload: {            // Structured data
    fields: {
      message: string;      // Main message
      [key: string]: any;   // Variables from the log
    };
    target?: string;        // Service name
  };
  
  // ... other fields
}
```

#### Requirements

- Claude API key must be set in extension settings
- Internet connection to call Claude API during initial parsing

#### Performance Considerations

- The API is only called once per log set, when patterns haven't been generated yet
- After patterns are generated, parsing is done locally using JavaScript regex
- The system uses the more cost-effective Claude Haiku model for pattern generation
- Sample collection is limited to 20 log lines to stay within token limits

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the `ClaudeService` and introducing a new `RegexLogParser` that utilizes regex patterns generated by Claude for parsing log lines, improving log analysis efficiency.

### Detailed summary
- Updated `version` in `package.json` from `0.4.11` to `0.4.12`.
- Added `RegexPattern` interface in `src/claudeService.ts`.
- Introduced `haikuModel` for regex generation.
- Implemented `generateLogParsingRegex` method for regex pattern generation.
- Added `callClaudeForRegexPatterns` method for API interaction.
- Created new `RegexLogParser` class for parsing log lines using generated patterns.
- Enhanced log entry creation with improved field extraction and normalization.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->