### PR TITLE
feat(code search): Use filenames and line numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traceback",
-  "version": "0.4.3",
+  "version": "0.4.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traceback",
-      "version": "0.4.3",
+      "version": "0.4.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@axiomhq/js": "^1.3.1",
@@ -18,7 +18,7 @@
         "@types/glob": "^7.2.0",
         "@types/node": "^16.18.36",
         "@types/node-fetch": "^2.6.12",
-        "@types/vscode": "^1.60.0",
+        "@types/vscode": "^1.74.0",
         "@typescript-eslint/eslint-plugin": "^5.59.11",
         "@typescript-eslint/parser": "^5.59.11",
         "@vscode/vsce": "^3.3.2",
@@ -30,7 +30,7 @@
         "webpack-cli": "^6.0.1"
       },
       "engines": {
-        "vscode": "^1.60.0"
+        "vscode": "^1.74.0"
       }
     },
     "node_modules/@axiomhq/js": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",

--- a/src/claudeService.ts
+++ b/src/claudeService.ts
@@ -433,6 +433,14 @@ Use the analyze_callers function to return the results in the exact format requi
                                             type: "string",
                                             description: "Capture group name for service name"
                                         },
+                                        fileName: {
+                                            type: "string",
+                                            description: "Capture group name for source file name"
+                                        },
+                                        lineNumber: {
+                                            type: "string",
+                                            description: "Capture group name for source line number"
+                                        }
                                     },
                                     additionalProperties: true
                                 }
@@ -452,6 +460,15 @@ Use the analyze_callers function to return the results in the exact format requi
 3. Variables - values shown in the log (e.g., "user_id=123") - if present
 4. Timestamp - in any format - if present
 5. Service name or component - if present
+6. File name - source file where the log originated - if present
+7. Line number - source line number in the file - if present
+
+Pay special attention to file names and line numbers which might appear in formats like:
+- at fileName:lineNumber
+- in fileName line lineNumber
+- fileName(lineNumber)
+- [fileName:lineNumber]
+- fileName.ext:lineNumber
 
 Log samples:
 ${selectedSamples.map((sample, i) => `${i+1}. ${sample}`).join('\n')}`;
@@ -482,7 +499,15 @@ The pattern should be comprehensive enough to extract:
 - timestamp: The timestamp in any format, if present
 - message: The main log message content
 - serviceName: The name of the service or component generating the log
+- fileName: The source file name if present (with or without extension)
+- lineNumber: The line number in the source file if present
 - Any other relevant fields
+
+For file names and line numbers, ensure the patterns can handle:
+- Various delimiters between file name and line number (:, line, at line, etc.)
+- File names with or without extensions
+- File paths (partial or full)
+- Line numbers in different formats (parentheses, brackets, after "line", etc.)
 
 Ensure the regex patterns:
 - Are compatible with JavaScript's regular expression engine

--- a/src/logExplorer.ts
+++ b/src/logExplorer.ts
@@ -905,9 +905,48 @@ export class LogTreeItem extends vscode.TreeItem {
   private static idCounter = 0;  // Keep the counter for unique IDs
 
   constructor(public readonly log: LogEntry) {
-    // Use the message field directly, fall back to rawText only if necessary
-    const message = log.message || log.rawText || 'No message';
-    const truncatedMessage = LogTreeItem.truncateMessage(message);
+    let fullMessage: string;
+
+    // Handle Axiom trace format
+    if (log.axiomSpan) {
+      // Use span name as the main message
+      const operationName = log.axiomSpan.name || 'Unknown operation';
+
+      // Build extra information from important attributes
+      let attributeInfo = '';
+      const importantAttrs = [
+        'http.method',
+        'http.status_code',
+        'error',
+        'rpc.method',
+        'attributes.http.method',
+        'attributes.http.status_code',
+        'attributes.error.type'
+      ];
+
+      for (const attrName of importantAttrs) {
+        if (log.axiomSpan[attrName]) {
+          attributeInfo += ` [${attrName.replace('attributes.', '')}=${log.axiomSpan[attrName]}]`;
+        }
+      }
+
+      // Include duration if available
+      const duration = log.axiomSpan.duration ? ` (${log.axiomSpan.duration})` : '';
+
+      fullMessage = `${operationName}${duration}${attributeInfo}`;
+    }
+    // Handle original log format
+    else if (log.jsonPayload?.fields) {
+      const message = log.jsonPayload.fields.message || '';
+      const chain = log.jsonPayload.fields.chain ? `[${log.jsonPayload.fields.chain}] ` : '';
+      fullMessage = `${chain}${message}`;
+    }
+    // Fallback to unified message field or rawText
+    else {
+      fullMessage = log.message || log.rawText || 'No message';
+    }
+
+    const truncatedMessage = LogTreeItem.truncateMessage(fullMessage);
     super(truncatedMessage, vscode.TreeItemCollapsibleState.None);
 
     // Generate a unique ID by combining available identifiers with a counter

--- a/src/logExplorer.ts
+++ b/src/logExplorer.ts
@@ -680,17 +680,8 @@ export class LogExplorerProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     // First try using Claude's analysis if available
     if (analysis?.staticSearchString) {
-      searchResult = await findCodeLocation(
-        { ...log, message: analysis.staticSearchString },
-        repoPath
-      );
+      searchResult = await findCodeLocation(analysis.staticSearchString);
     }
-    
-    // Then try with the regular message from the log
-    if (!searchResult) {
-      searchResult = await findCodeLocation(log, repoPath);
-    }
-    
     // Last resort: try to find files based on the service/target name
     if (!searchResult) {
       const serviceName = log.target || log.serviceName || '';

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -327,7 +327,7 @@ export class PlainTextLogParser implements LogParser {
       extract: (matches: RegExpExecArray) => {
         const fields = matches[3]?.trim();
         const fieldMap: Record<string, string> = {};
-        
+
         // Extract key=value pairs, handling quoted values
         const fieldRegex = /([^=\s]+)=(?:"([^"]*)"|([^\s]*))/g;
         let fieldMatch;
@@ -336,7 +336,7 @@ export class PlainTextLogParser implements LogParser {
           const value = fieldMatch[2] || fieldMatch[3]; // quoted or unquoted value
           fieldMap[key] = value;
         }
-        
+
         return {
           timestamp: matches[1]?.trim(),
           severity: matches[2]?.trim().toUpperCase(),
@@ -399,7 +399,7 @@ export class PlainTextLogParser implements LogParser {
     if (!line.trim()) {
       return { matched: false, data: {} };
     }
-    
+
     // Try all registered patterns
     for (const pattern of this.patterns) {
       const matches = pattern.regex.exec(line);
@@ -410,26 +410,26 @@ export class PlainTextLogParser implements LogParser {
         };
       }
     }
-    
+
     // If no pattern matched, perform basic heuristic extraction
     try {
       // Try to extract timestamp and severity using common patterns
       const timestampMatch = line.match(/^(\d{4}-\d{2}-\d{2}[T\s]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[-+]\d{4})?)/);
       const timestamp = timestampMatch ? timestampMatch[1] : null;
-      
+
       const severityMatch = line.match(/\b(TRACE|DEBUG|INFO|WARN(?:ING)?|ERROR|FATAL|CRITICAL)\b/i);
       const severity = severityMatch ? severityMatch[0].toUpperCase() : null;
-      
+
       // Try to identify a service name or module
-      const remainingText = timestampMatch && severityMatch 
+      const remainingText = timestampMatch && severityMatch
         ? line.replace(timestampMatch[0], '').replace(severityMatch[0], '').trim()
         : line.trim();
-      
+
       // Look for module/service pattern with colon
       const moduleMatch = remainingText.match(/^([a-zA-Z0-9_.:]+):(.+)$/);
       const serviceName = moduleMatch ? moduleMatch[1].trim() : '';
       const message = moduleMatch ? moduleMatch[2].trim() : remainingText;
-      
+
       // If we found at least a timestamp or severity, consider it a match
       if (timestamp || severity) {
         return {
@@ -452,7 +452,7 @@ export class PlainTextLogParser implements LogParser {
   private createLogEntry(data: any, rawLine: string): LogEntry {
     // Determine severity - first use data.severity if present, then detect from content
     let severity = data.severity || '';
-    
+
     // If severity not provided by pattern, try to detect from line content
     if (!severity) {
       if (rawLine.toLowerCase().includes('error') || rawLine.toLowerCase().includes('exception')) {
@@ -469,7 +469,7 @@ export class PlainTextLogParser implements LogParser {
         severity = 'INFO'; // Default to INFO if we can't detect
       }
     }
-    
+
     // Normalize severity to standard values
     severity = this.normalizeSeverity(severity);
 
@@ -513,13 +513,13 @@ export class PlainTextLogParser implements LogParser {
       serviceName: serviceName || ''
     };
   }
-  
+
   /**
    * Normalize severity level to standard values
    */
   private normalizeSeverity(severity: string): string {
     const upperSeverity = severity.toUpperCase();
-    
+
     // Map to standard severity levels
     if (upperSeverity.includes('TRACE')) {
       return 'TRACE';
@@ -532,7 +532,7 @@ export class PlainTextLogParser implements LogParser {
     } else if (upperSeverity.includes('ERROR') || upperSeverity.includes('FATAL') || upperSeverity.includes('CRIT')) {
       return 'ERROR';
     }
-    
+
     // Default to INFO if no match
     return 'INFO';
   }
@@ -562,7 +562,7 @@ export class RegexLogParser implements LogParser {
   async parse(content: string): Promise<LogEntry[]> {
     // Split content into lines
     const lines = content.split('\n').filter(line => line.trim().length > 0);
-    
+
     // If we have no patterns yet, collect sample logs
     if (this.patterns.length === 0 && !this.hasGeneratedPatterns) {
       // Add new samples to our collection, up to the maximum
@@ -576,13 +576,13 @@ export class RegexLogParser implements LogParser {
           break;
         }
       }
-      
+
       // If we have enough samples or this is a large log set, generate patterns
       if (this.sampleLogs.length >= this.maxSampleLogs || lines.length > 50) {
         await this.generatePatterns();
       }
     }
-    
+
     // If we're still missing patterns, generate them now
     if (this.patterns.length === 0) {
       // If we don't have enough samples, use what we've got
@@ -590,14 +590,14 @@ export class RegexLogParser implements LogParser {
         // Take a sample from the current logs
         this.sampleLogs = lines.slice(0, this.maxSampleLogs);
       }
-      
+
       await this.generatePatterns();
     }
-    
+
     // Now we should have patterns - parse the logs
     return this.parseWithPatterns(lines);
   }
-  
+
   /**
    * Use Claude to generate regex patterns based on sample logs
    */
@@ -609,17 +609,17 @@ export class RegexLogParser implements LogParser {
         this.hasGeneratedPatterns = true; // Mark as tried
         return;
       }
-      
+
       console.log(`Generating regex patterns from ${this.sampleLogs.length} sample logs...`);
-      
+
       // Call Claude to generate patterns
       this.patterns = await this.claudeService.generateLogParsingRegex(this.sampleLogs);
-      
+
       console.log(`Generated ${this.patterns.length} regex patterns`);
-      
+
       // Mark that we've generated patterns to avoid repeatedly trying if it fails
       this.hasGeneratedPatterns = true;
-      
+
       // Compile all the patterns for efficiency
       this.patterns.forEach(pattern => {
         try {
@@ -635,7 +635,7 @@ export class RegexLogParser implements LogParser {
       this.hasGeneratedPatterns = true; // Mark as tried to avoid retry spam
     }
   }
-  
+
   /**
    * Parse all logs using the generated patterns
    */
@@ -653,10 +653,10 @@ export class RegexLogParser implements LogParser {
     
     for (const line of lines) {
       if (!line.trim()) continue;
-      
+
       // Try each pattern in order until one matches
       let matched = false;
-      
+
       for (const patternObj of this.patterns) {
         try {
           // Validate pattern object
@@ -667,17 +667,17 @@ export class RegexLogParser implements LogParser {
 
           const regex = new RegExp(patternObj.pattern);
           const match = regex.exec(line);
-          
+
           if (match) {
             // Extract fields based on the pattern's extraction map
             const extractedData: Record<string, string> = {};
-            
+
             for (const [logEntryField, captureGroupName] of Object.entries(patternObj.extractionMap)) {
               if (match.groups && match.groups[captureGroupName]) {
                 extractedData[logEntryField] = match.groups[captureGroupName];
               }
             }
-            
+
             // Create LogEntry from extracted data
             logs.push(this.createLogEntry(extractedData, line));
             matched = true;
@@ -688,24 +688,24 @@ export class RegexLogParser implements LogParser {
           continue;
         }
       }
-      
+
       // If no pattern matched, fall back to heuristic parsing
       if (!matched) {
         // Try to extract basic fields using heuristics
         logs.push(this.createFallbackLogEntry(line));
       }
     }
-    
+
     return logs;
   }
-  
+
   /**
    * Create a LogEntry from the extracted fields
    */
   private createLogEntry(data: Record<string, string>, rawLine: string): LogEntry {
     // Ensure required fields have sensible defaults
     const severity = this.normalizeSeverity(data.severity || '');
-    
+
     // Process timestamp
     let timestamp = data.timestamp || new Date().toISOString();
     if (data.timestamp) {
@@ -717,7 +717,7 @@ export class RegexLogParser implements LogParser {
         timestamp = new Date().toISOString(); // Use current time as fallback
       }
     }
-    
+
     // Ensure other fields are defined
     const serviceName = data.serviceName || data.target || '';
     const message = data.message || rawLine;
@@ -734,7 +734,7 @@ export class RegexLogParser implements LogParser {
         variables[varName] = value;
       }
     });
-    
+
     return {
       severity,
       timestamp,
@@ -753,13 +753,13 @@ export class RegexLogParser implements LogParser {
       }
     };
   }
-  
+
   /**
    * Create a basic LogEntry when no pattern matches
    */
   private createFallbackLogEntry(rawLine: string): LogEntry {
     let severity = 'INFO';
-    
+
     // Try to detect severity from content
     if (rawLine.toLowerCase().includes('error') || rawLine.toLowerCase().includes('exception')) {
       severity = 'ERROR';
@@ -770,18 +770,18 @@ export class RegexLogParser implements LogParser {
     } else if (rawLine.toLowerCase().includes('info')) {
       severity = 'INFO';
     }
-    
+
     // Try to extract service name if there's a pipe separator
     let serviceName = 'unknown';
     let message = rawLine;
-    
+
     // Common format: service | message
     const pipeMatch = rawLine.match(/^([^|]+)\|\s*(.+)$/);
     if (pipeMatch) {
       serviceName = pipeMatch[1].trim();
       message = pipeMatch[2].trim();
     }
-    
+
     return {
       severity,
       timestamp: new Date().toISOString(),
@@ -797,13 +797,13 @@ export class RegexLogParser implements LogParser {
       }
     };
   }
-  
+
   /**
    * Normalize severity levels to standard values
    */
   private normalizeSeverity(severity: string): string {
     const upperSeverity = severity.toUpperCase();
-    
+
     if (upperSeverity.includes('TRACE')) {
       return 'TRACE';
     } else if (upperSeverity.includes('DEBUG')) {
@@ -815,7 +815,7 @@ export class RegexLogParser implements LogParser {
     } else if (upperSeverity.includes('ERROR') || upperSeverity.includes('FATAL') || upperSeverity.includes('CRIT')) {
       return 'ERROR';
     }
-    
+
     // Default to INFO if no match
     return 'INFO';
   }
@@ -849,10 +849,10 @@ export class ExtensibleLogParser implements LogParser {
       console.warn('Empty or invalid log content provided');
       return [];
     }
-    
+
     // Detect content format by examining the first few lines
     const sampleLines = content.split('\n').slice(0, 10).filter(line => line.trim().length > 0);
-    
+
     // Try each parser in order
     for (const parser of this.plugins) {
       if (parser.canParse(content)) {
@@ -870,17 +870,17 @@ export class ExtensibleLogParser implements LogParser {
     // If no dedicated parser handled it, try a fallback approach
     // This is useful for new log formats that don't match any existing pattern
     console.warn('No dedicated parser matched, attempting fallback parsing');
-    
+
     // Create a fallback parser that tries to handle line-by-line
     const fallbackParser = new PlainTextLogParser();
     const fallbackResult = await fallbackParser.parse(content);
-    
+
     // If we got any valid logs from fallback parsing, return them
     if (fallbackResult && fallbackResult.length > 0) {
       console.log(`Log parsed with fallback parser, found ${fallbackResult.length} entries`);
       return fallbackResult;
     }
-    
+
     // If still no results, return empty array
     console.warn('No suitable parser found for the log content');
     return [];
@@ -977,7 +977,7 @@ export async function loadLogs(logPathOrUrl: string): Promise<LogEntry[]> {
  * Find the code location based on log information
  * This function has been simplified to better handle arbitrary log formats
  */
-export async function findCodeLocation(log: LogEntry, repoPath: string): Promise<{ file: string; line: number }> {
+export async function findCodeLocation(query: string): Promise<{ file: string; line: number }> {
   try {
     // Progress indicator
     const result = await vscode.window.withProgress({
@@ -986,39 +986,29 @@ export async function findCodeLocation(log: LogEntry, repoPath: string): Promise
       cancellable: false
     }, async (progress) => {
       // Extract searchable content from the log, prioritizing normalized fields
-      let searchContent: string = log.message || '';
+      
+      // Clean up search content before searching
+      // Remove log level indicators like [INFO], [DEBUG], etc.
+      query = query.replace(/\[\s*(INFO|DEBUG|WARN|WARNING|ERROR|TRACE)\s*\]\s*/gi, '');
 
-      // If we still couldn't find anything searchable, we can't locate the source
-      if (!searchContent || searchContent.trim().length < 3) {
-        console.warn('No searchable content found in log entry');
-        throw new Error('No searchable content found in log entry');
-      }
-      
+      // Remove timestamps and date patterns
+      query = query.replace(/\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}(\.\d+)?(\s*[+-]\d{4})?\s*/, '');
+      query = query.replace(/\d{2}:\d{2}:\d{2}(\.\d+)?\s*/, '');
+
+      // Remove special characters (quotes, brackets, parentheses, etc.)
+      query = query.replace(/['"[\](){}<>]/g, '');
+      // Remove other special characters but keep spaces and alphanumeric
+      query = query.replace(/[^a-zA-Z0-9\s]/g, ' ');
+      // Replace multiple spaces with a single space
+      query = query.replace(/\s+/g, ' ');
+
       // Trim whitespace from resulting search content
-      const query = searchContent.trim();
-      
+      query = query.trim();
+
       // Verify we still have searchable content after cleaning
       if (!query || query.trim().length < 3) {
         console.warn('No searchable content left after cleaning log patterns');
         throw new Error('No searchable content found after cleaning log patterns');
-      }
-
-      // Extract target path hints from the log
-      // Start with the unified target/serviceName fields
-      let targetPath = log.target || log.serviceName || '';
-
-      // If no target found, try format-specific fields
-      if (!targetPath) {
-        if (log.axiomSpan) {
-          // Check for source code attributes
-          targetPath = log.axiomSpan['attributes.code.filepath'] ||
-                       log.axiomSpan['code.filepath'] ||
-                       log.axiomSpan['attributes.code.namespace'] ||
-                       log.axiomSpan['code.namespace'] || '';
-        }
-        else if (log.jsonPayload?.target) {
-          targetPath = log.jsonPayload.target;
-        }
       }
 
       progress.report({ message: 'Searching for matching source files...' });
@@ -1028,24 +1018,23 @@ export async function findCodeLocation(log: LogEntry, repoPath: string): Promise
       if (!workspaceFolders || workspaceFolders.length === 0) {
         throw new Error('No workspace folder is open');
       }
-      
+
       // Use the first workspace folder as the root
       const workspaceRoot = workspaceFolders[0].uri.fsPath;
-      
-      
+
       // Function to search a file for the query
       async function searchFile(filePath: string, query: string): Promise<{ line: number } | null> {
         try {
           const content = fs.readFileSync(filePath, 'utf8');
-          
+
           // First check if the file contains the query at all before line-by-line processing
           if (!content.includes(query)) {
             return null;
           }
-          
+
           // Only if the file contains the query, proceed with line-by-line search
           const lines = content.split('\n');
-          
+
           for (let i = 0; i < lines.length; i++) {
             const line = lines[i];
             if (line.toLowerCase().includes(query.toLowerCase())) {
@@ -1058,48 +1047,37 @@ export async function findCodeLocation(log: LogEntry, repoPath: string): Promise
           return null;
         }
       }
-      
+
       // Find all applicable source files
       progress.report({ message: 'Finding source files...' });
       let filesToSearch = await vscode.workspace.findFiles(
         '**/*.{ts,tsx,js,jsx,vue,svelte,rs,go,py,java,cs,cpp,c,h,rb,php}',
         '**/[node_modules,dist,build,.git,logs]/**'
       );
-      
-      // If we have a target path, prioritize matching files
-      if (targetPath) {
-        const targetLower = targetPath.toLowerCase();
-        filesToSearch.sort((a, b) => {
-          const aContains = a.fsPath.toLowerCase().includes(targetLower) ? -1 : 0;
-          const bContains = b.fsPath.toLowerCase().includes(targetLower) ? -1 : 0;
-          return aContains - bContains;
-        });
-      }
-      
+
       // Remove the file limit to search the entire codebase
       console.log(`Searching all ${filesToSearch.length} files in the codebase`);
-      
+
       // Search through the files
       let searchCount = 0;
-      
-      
+
       progress.report({ message: `Searching for "${query}" (processed ${searchCount} files)` });
-      
+
       // Progress files in batches for better responsiveness
       const BATCH_SIZE = 50;
-      
+
       // Function to search all files with a given query
       async function searchAllFiles(searchQuery: string): Promise<{file: string; line: number} | null> {
         for (let i = 0; i < filesToSearch.length; i += BATCH_SIZE) {
           const batch = filesToSearch.map(file => file.fsPath).slice(i, i + BATCH_SIZE);
-          
+
           // Search files in parallel
           const batchPromises = batch.map(async (file) => {
             searchCount++;
             if (searchCount % 100 === 0) {
               progress.report({ message: `Searching for "${searchQuery}" (processed ${searchCount} files)` });
             }
-            
+
             const match = await searchFile(file, searchQuery);
             if (match) {
               const relativePath = path.relative(workspaceRoot, file);
@@ -1107,50 +1085,50 @@ export async function findCodeLocation(log: LogEntry, repoPath: string): Promise
             }
             return null;
           });
-          
+
           const batchResults = await Promise.all(batchPromises);
           const validMatches = batchResults.filter(m => m !== null) as Array<{ file: string; line: number }>;
-          
+
           if (validMatches.length > 0) {
             return validMatches[0];
           }
         }
-        
+
         return null; // No matches found
       }
-      
+
       // First, try with the exact query
       progress.report({ message: `Searching for exact match: "${query}"` });
       const exactMatch = await searchAllFiles(query);
-      
+
       if (exactMatch) {
         return exactMatch;
       }
-      
+
       // If exact match failed, try with variations
       const words = query.split(/\s+/).filter(w => w.length > 0);
-      
+
       // Only try variations if we have multiple words
       if (words.length > 4) {
         progress.report({ message: `No exact match found, trying variations...` });
-        
+
         // Generate variations by removing words from front and back
         const variations: string[] = [];
-        
+
         // Remove words from the front (1, 2, 3, etc.)
         for (let i = 1; i < words.length; i++) {
           const frontVariation = words.slice(i).join(' ');
           if (frontVariation.length >= 3) {
             variations.push(frontVariation);
           }
-          
+
           // Remove words from the back (1, 2, 3, etc.)
           const backVariation = words.slice(0, words.length - i).join(' ');
           if (backVariation.length >= 3) {
             variations.push(backVariation);
           }
         }
-        
+
         // Try each variation until we find a match
         for (const variation of variations) {
           progress.report({ message: `Trying variation: "${variation}"` });
@@ -1160,7 +1138,7 @@ export async function findCodeLocation(log: LogEntry, repoPath: string): Promise
           }
         }
       }
-      
+
       return null; // No matches found with any variation
     });
 

--- a/src/variableDecorator.ts
+++ b/src/variableDecorator.ts
@@ -353,8 +353,11 @@ export class VariableDecorator {
         // If we found matches, calculate relevance scores
         if (matches.length > 0) {
           // Get log line number if available
-          const searchResult = await findCodeLocation(log.claudeAnalysis?.staticSearchString || log.message || log.rawText || '');
-          const logLineNumber = searchResult ? searchResult.line : -1;
+          let logLineNumber = -1;
+          if (log.claudeAnalysis?.staticSearchString) {
+            const searchResult = await findCodeLocation(log.claudeAnalysis.staticSearchString);
+            logLineNumber = searchResult ? searchResult.line : -1;
+          }
           
           // Calculate scores for each match
           for (const match of matches) {


### PR DESCRIPTION
### Description

It adds the ability to parse filenames and line numbers using both JSON and REGEX parsers. When present, this code info will be used to show the correct location.

### Other changes

Fixes a bug where loading logs fails when there is a faulty regex returned by Claude.

### Tested
Yes. Tested on:
- boomerang logs
- otel logs
- hyperlane logs
- neon logs

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the `TraceBack` VS Code extension to improve log analysis features, enhance versioning, and refine variable tracking. It adds new properties for file names and line numbers in logs, updates dependencies, and improves parsing logic.

### Detailed summary
- Updated `version` in `package.json` to `0.4.14`.
- Updated `version` in `package-lock.json` to `0.4.13`.
- Added `fileName` and `lineNumber` properties in log entries.
- Enhanced log analysis to include file name and line number extraction.
- Improved regex patterns for log parsing.
- Refined variable scoring and analysis in `VariableDecorator`.
- Updated `findCodeLocation` function to accept string queries.
- Enhanced error handling and logging in various methods.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->