### PR TITLE
feat(ollama): adds support for ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,22 @@ A VS Code extension that brings telemetry data (traces, logs, and metrics) into 
 
     <img width="376" alt="image" src="https://github.com/user-attachments/assets/681d10f6-d4c3-4478-9bf4-7790b272a050" />
 
-1. Set Claude API Key
+1. Configure LLM Provider (Claude API or Local Ollama)
+
+    You can use either Anthropic's Claude API (requires an API key) or a local Ollama instance.
 
     <img width="609" alt="image" src="https://github.com/user-attachments/assets/da51c800-1393-47e8-b5de-32026ac23938" />
+
+    ### Using Ollama (Local LLM)
+    
+    If you prefer to use a local LLM through Ollama:
+    
+    1. Install Ollama from [ollama.ai](https://ollama.ai)
+    2. Pull a model like Llama 3: `ollama pull llama3`
+    3. Start Ollama (it will run on http://localhost:11434 by default)
+    4. In TraceBack settings, select "Ollama (Local)" as the LLM provider
+    5. Enter the endpoint URL (default: http://localhost:11434)
+    6. Select the model name (default: llama3)
 
 1. Click on a log
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.15",
+  "version": "0.4.14",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "traceback",
   "displayName": "TraceBack",
   "description": "A VS Code extension that brings telemetry data (traces, logs, and metrics) into your code.",
-  "version": "0.4.14",
+  "version": "0.4.15",
   "publisher": "hyperdrive-eng",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,22 @@
               "type": "string",
               "default": "",
               "description": "API key for Claude AI service"
+          },
+          "traceback.llmProvider": {
+              "type": "string",
+              "enum": ["claude", "ollama"],
+              "default": "claude",
+              "description": "LLM provider to use (Claude or Ollama)"
+          },
+          "traceback.ollamaEndpoint": {
+              "type": "string",
+              "default": "http://localhost:11434",
+              "description": "Endpoint URL for Ollama API"
+          },
+          "traceback.ollamaModel": {
+              "type": "string",
+              "default": "llama3",
+              "description": "Model name to use with Ollama"
           }
       }
     },
@@ -46,6 +62,21 @@
       {
         "command": "traceback.setClaudeApiKey",
         "title": "Set Claude API Key",
+        "category": "TraceBack"
+      },
+      {
+        "command": "traceback.setOllamaEndpoint",
+        "title": "Set Ollama Endpoint",
+        "category": "TraceBack"
+      },
+      {
+        "command": "traceback.setOllamaModel",
+        "title": "Set Ollama Model",
+        "category": "TraceBack"
+      },
+      {
+        "command": "traceback.setLlmProvider",
+        "title": "Set LLM Provider (Claude/Ollama)",
         "category": "TraceBack"
       },
       {

--- a/src/callStackExplorer.ts
+++ b/src/callStackExplorer.ts
@@ -1,7 +1,7 @@
 import * as vscode from 'vscode';
 import { LogEntry, Span } from './logExplorer';
-import { CallerAnalysis } from './claudeService';
-import { ClaudeService } from './claudeService';
+import { CallerAnalysis } from './llmService';
+import { LLMServiceFactory } from './llmService';
 import * as path from 'path';
 import { logLineDecorationType } from './decorations';
 
@@ -143,7 +143,7 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<CallSt
 
   private currentLogEntry: LogEntry | undefined;
   private callerAnalysis: CallerNode[] = [];
-  private claudeService: ClaudeService = ClaudeService.getInstance();
+  private llmService = LLMServiceFactory.getInstance().createLLMService();
   private isAnalyzing: boolean = false;
   private callStackCache: Map<string, CallStackCache> = new Map();
 
@@ -428,7 +428,7 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<CallSt
         ''
       ).filter(msg => msg);
 
-      const analysis = await this.claudeService.analyzeCallers(
+      const analysis = await this.llmService.analyzeCallers(
         currentLogLine,
         staticSearchString,
         allLogLines,
@@ -565,7 +565,7 @@ export class CallStackExplorerProvider implements vscode.TreeDataProvider<CallSt
           const lineText = document.lineAt(caller.lineNumber).text;
           
           // Analyze callers
-          const analysis = await this.claudeService.analyzeCallers(
+          const analysis = await this.llmService.analyzeCallers(
             lineText,
             lineText,
             [],

--- a/src/llmService.ts
+++ b/src/llmService.ts
@@ -1,0 +1,133 @@
+import * as vscode from 'vscode';
+
+export interface LLMLogAnalysis {
+    staticSearchString: string;
+    variables: Record<string, any>;
+}
+
+export interface CallerAnalysis {
+    rankedCallers: Array<{
+        filePath: string;
+        lineNumber: number;
+        code: string;
+        functionName: string;
+        confidence: number;
+        explanation: string;
+    }>;
+}
+
+export interface RegexPattern {
+    pattern: string;
+    description: string;
+    extractionMap: Record<string, string>;
+}
+
+export interface LLMService {
+    analyzeLog(logMessage: string, language: string): Promise<LLMLogAnalysis>;
+    analyzeCallers(
+        currentLogLine: string,
+        staticSearchString: string,
+        allLogLines: string[],
+        potentialCallers: Array<{ filePath: string; lineNumber: number; code: string; functionName: string; functionRange?: vscode.Range }>
+    ): Promise<CallerAnalysis>;
+    generateLogParsingRegex(
+        logSamples: string[],
+        expectedResults?: Record<string, any>[]
+    ): Promise<RegexPattern[]>;
+}
+
+export class LLMServiceFactory {
+    private static instance: LLMServiceFactory;
+    private static serviceInstance: LLMService | null = null;
+    private static currentProvider: string = '';
+    
+    private constructor() {}
+    
+    public static getInstance(): LLMServiceFactory {
+        if (!LLMServiceFactory.instance) {
+            LLMServiceFactory.instance = new LLMServiceFactory();
+        }
+        return LLMServiceFactory.instance;
+    }
+    
+    public createLLMService(): LLMService {
+        const config = vscode.workspace.getConfiguration('traceback');
+        const usedLLMProvider = config.get<string>('llmProvider') || 'claude';
+        
+        // Only create a new instance if the provider has changed or we don't have an instance yet
+        if (LLMServiceFactory.serviceInstance === null || LLMServiceFactory.currentProvider !== usedLLMProvider) {
+            console.log(`Creating new LLM service instance for provider: ${usedLLMProvider}`);
+            
+            if (usedLLMProvider === 'ollama') {
+                const ollamaEndpoint = config.get<string>('ollamaEndpoint');
+                if (!ollamaEndpoint) {
+                    throw new Error('Ollama endpoint not set. Please set an Ollama endpoint first.');
+                }
+                
+                // Dynamically import to avoid circular dependencies
+                const OllamaService = require('./ollamaService').OllamaService;
+                LLMServiceFactory.serviceInstance = OllamaService.getInstance();
+            } else {
+                // Default to Claude
+                // Dynamically import to avoid circular dependencies
+                const ClaudeService = require('./claudeService').ClaudeService;
+                LLMServiceFactory.serviceInstance = ClaudeService.getInstance();
+            }
+            
+            // Update the current provider
+            LLMServiceFactory.currentProvider = usedLLMProvider;
+        }
+        
+        // Since we either already had a service instance or just created one, it should never be null here
+        return LLMServiceFactory.serviceInstance!;
+    }
+    
+    // Force recreate the service instance (useful when settings change)
+    public static resetServiceInstance(): void {
+        LLMServiceFactory.serviceInstance = null;
+        LLMServiceFactory.currentProvider = '';
+    }
+}
+
+export function filterRelevantLogs(currentLogLine: string, allLogLines: string[], maxLines: number): string[] {
+    // Find the index of the current log line
+    const currentIndex = allLogLines.indexOf(currentLogLine);
+    if (currentIndex === -1) {
+        return [currentLogLine];
+    }
+
+    // Get surrounding context (prefer more recent logs)
+    const beforeCount = Math.floor(maxLines * 0.3); // 30% before
+    const afterCount = Math.floor(maxLines * 0.7);  // 70% after
+
+    const start = Math.max(0, currentIndex - beforeCount);
+    const end = Math.min(allLogLines.length, currentIndex + afterCount);
+
+    // Get the logs within our window
+    const contextLogs = allLogLines.slice(start, end);
+
+    // If we have room for more logs, try to find similar logs by pattern matching
+    if (contextLogs.length < maxLines) {
+        const remainingSlots = maxLines - contextLogs.length;
+        const patternLogs = findSimilarLogs(currentLogLine, allLogLines, contextLogs, remainingSlots);
+        return [...new Set([...contextLogs, ...patternLogs])];
+    }
+
+    return contextLogs;
+}
+
+export function findSimilarLogs(currentLogLine: string, allLogLines: string[], excludeLogs: string[], maxCount: number): string[] {
+    // Simple similarity check based on word overlap
+    const currentWords = new Set(currentLogLine.toLowerCase().split(/\s+/));
+
+    return allLogLines
+        .filter(log => !excludeLogs.includes(log)) // Exclude logs we already have
+        .map(log => {
+            const words = log.toLowerCase().split(/\s+/);
+            const overlap = words.filter(word => currentWords.has(word)).length;
+            return { log, similarity: overlap / Math.max(words.length, currentWords.size) };
+        })
+        .sort((a, b) => b.similarity - a.similarity) // Sort by similarity
+        .slice(0, maxCount) // Take top N
+        .map(item => item.log);
+}

--- a/src/ollamaService.ts
+++ b/src/ollamaService.ts
@@ -294,7 +294,7 @@ Your response must be in JSON format with the following structure:
                     },
                     body: JSON.stringify(request),
                     // Add a reasonable timeout
-                    timeout: 30000
+                    timeout: 120000
                 });
             } catch (fetchError) {
                 console.error('OllamaService: Network error when connecting to Ollama:', fetchError);

--- a/src/ollamaService.ts
+++ b/src/ollamaService.ts
@@ -1,0 +1,475 @@
+import * as vscode from 'vscode';
+import fetch from 'node-fetch';
+import { LLMService, LLMLogAnalysis, CallerAnalysis, RegexPattern, filterRelevantLogs } from './llmService';
+
+export class OllamaService implements LLMService {
+    private static instance: OllamaService;
+    private endpoint: string | undefined;
+    private model: string = 'llama3'; // Default model
+
+    private constructor() {
+        // Load endpoint from workspace state if available
+        const config = vscode.workspace.getConfiguration('traceback');
+        this.endpoint = config.get('ollamaEndpoint');
+        
+        // Load model from workspace state if available
+        const configModel = config.get<string>('ollamaModel');
+        if (configModel) {
+            this.model = configModel;
+        }
+    }
+
+    public static getInstance(): OllamaService {
+        if (!OllamaService.instance) {
+            OllamaService.instance = new OllamaService();
+        }
+        return OllamaService.instance;
+    }
+
+    public async setEndpoint(endpoint: string): Promise<void> {
+        this.endpoint = endpoint;
+        await vscode.workspace.getConfiguration('traceback').update('ollamaEndpoint', endpoint, true);
+    }
+    
+    public async setModel(model: string): Promise<void> {
+        this.model = model;
+        await vscode.workspace.getConfiguration('traceback').update('ollamaModel', model, true);
+    }
+
+    public async analyzeLog(logMessage: string, language: string): Promise<LLMLogAnalysis> {
+        if (!this.endpoint) {
+            throw new Error('Ollama endpoint not set. Please set your endpoint first.');
+        }
+
+        try {
+            console.log('OllamaService: Analyzing log message with model:', this.model);
+            console.log('OllamaService: Using endpoint:', this.endpoint);
+            
+            const prompt = `Analyze this log message and extract:
+1. Think and infer a possibly longest static substring that can be searched in the code base.
+2. Key-value pairs of any variables or dynamic values in the log
+
+Log message: "${logMessage}"
+
+Rules for static search string:
+- Predicted staticSearchString should be exact substring of logMessage. 
+- logMessage.substring(staticSearchString) should be true.
+- No regular expressions allowed.
+
+Rules for variables:
+- Extract all key-value pairs and dynamic values
+- Preserve variable names as they appear in the log
+
+Examples:
+Input: "[PlaceOrder] user_id=\"3790d414-165b-11f0-8ee4-96dac6adf53a\" user_currency=\"USD\""
+Static: "PlaceOrder"  (Note: brackets and log level removed)
+Variables: {
+  "user_id": "3790d414-165b-11f0-8ee4-96dac6adf53a",
+  "user_currency": "USD"
+}
+
+Your response must be in JSON format with the following structure:
+{
+  "staticSearchString": "the static search string",
+  "variables": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}`;
+
+            const response = await this.callOllama(prompt);
+            console.log('OllamaService: Got response from Ollama');
+            const jsonResponse = this.extractJsonFromResponse(response);
+            console.log('OllamaService: Extracted JSON:', JSON.stringify(jsonResponse).substring(0, 100) + '...');
+            return this.validateLogAnalysisResponse(jsonResponse, logMessage);
+        } catch (error) {
+            console.error('Error calling Ollama API:', error);
+            if (error instanceof Error) {
+                console.error('Error details:', error.message);
+                console.error('Error stack:', error.stack);
+                throw new Error(`Failed to analyze log message with Ollama: ${error.message}`);
+            }
+            throw new Error('Failed to analyze log message with Ollama');
+        }
+    }
+
+    public async analyzeCallers(
+        currentLogLine: string,
+        staticSearchString: string,
+        allLogLines: string[],
+        potentialCallers: Array<{ filePath: string; lineNumber: number; code: string; functionName: string; functionRange?: vscode.Range }>
+    ): Promise<CallerAnalysis> {
+        if (!this.endpoint) {
+            throw new Error('Ollama endpoint not set. Please set your endpoint first.');
+        }
+
+        try {
+            // Filter and limit log lines to prevent prompt too long errors
+            const MAX_LOG_LINES = 10; // Smaller limit for Ollama to prevent context overflow
+            const filteredLogs = filterRelevantLogs(currentLogLine, allLogLines, MAX_LOG_LINES);
+
+            const prompt = `Analyze these potential callers and rank them based on likelihood of being the actual caller.
+
+Current log line: "${currentLogLine}"
+Static search string used: "${staticSearchString}"
+
+Most relevant log lines from current session:
+${filteredLogs.map(log => `- ${log}`).join('\n')}
+
+Potential callers found in codebase:
+${potentialCallers.map(caller => `
+File: ${caller.filePath}
+Function: ${caller.functionName}
+Line ${caller.lineNumber}: ${caller.code}
+`).join('\n')}
+
+Rules for ranking:
+1. Consider the context from the provided log lines
+2. Look for patterns in function names and variable usage
+3. Consider the proximity of the code to related functionality
+4. Consider common logging patterns and practices
+5. Higher confidence for direct matches with the static search string
+6. Lower confidence for generic or utility functions that might just pass through the message
+
+Return a ranked list of callers, each with:
+- File path
+- Line number
+- Function name
+- Confidence score (0-1)
+- Explanation for the ranking
+
+Your response must be in JSON format with the following structure:
+{
+  "rankedCallers": [
+    {
+      "filePath": "path/to/file.js",
+      "lineNumber": 123,
+      "functionName": "someFunction",
+      "confidence": 0.95,
+      "explanation": "Explanation for why this is ranked here"
+    },
+    {
+      "filePath": "path/to/another/file.js",
+      "lineNumber": 456,
+      "functionName": "anotherFunction",
+      "confidence": 0.7, 
+      "explanation": "Explanation for why this is ranked here"
+    }
+  ]
+}`;
+
+            const response = await this.callOllama(prompt);
+            const jsonResponse = this.extractJsonFromResponse(response);
+            return this.validateCallerAnalysisResponse(jsonResponse);
+        } catch (error) {
+            console.error('Error analyzing callers with Ollama:', error);
+            throw new Error('Failed to analyze callers with Ollama');
+        }
+    }
+
+    public async generateLogParsingRegex(
+        logSamples: string[],
+        expectedResults?: Record<string, any>[]
+    ): Promise<RegexPattern[]> {
+        if (!this.endpoint) {
+            throw new Error('Ollama endpoint not set. Please set your endpoint first.');
+        }
+
+        try {
+            // Limit number of samples to avoid token limits
+            const MAX_SAMPLES = 10; // Smaller limit for Ollama
+            const selectedSamples = logSamples.slice(0, MAX_SAMPLES);
+
+            let prompt = `Generate regular expression patterns to parse these log lines into a structured format. We need to extract key components:
+
+1. Severity level (e.g., INFO, DEBUG, ERROR) - if present
+2. Message content - the main content of the log (required)
+3. Variables - values shown in the log (e.g., "user_id=123") - if present
+4. Timestamp - in any format - if present
+5. Service name or component - if present
+6. File name - source file where the log originated - if present
+7. Line number - source line number in the file - if present
+
+Pay special attention to file names and line numbers which might appear in formats like:
+- at fileName:lineNumber
+- in fileName line lineNumber
+- fileName(lineNumber)
+- [fileName:lineNumber]
+- fileName.ext:lineNumber
+
+Log samples:
+${selectedSamples.map((sample, i) => `${i+1}. ${sample}`).join('\n')}`;
+
+            // Add expected results for some samples if provided
+            if (expectedResults && expectedResults.length > 0) {
+                prompt += `\n\nFor some log lines, these are examples of the expected parsing results:`;
+                
+                for (let i = 0; i < Math.min(expectedResults.length, selectedSamples.length); i++) {
+                    prompt += `\n\nLog: ${selectedSamples[i]}\nParsed:`;
+                    
+                    Object.entries(expectedResults[i]).forEach(([key, value]) => {
+                        prompt += `\n  ${key}: ${JSON.stringify(value)}`;
+                    });
+                }
+            }
+
+            prompt += `\n
+Create one or more regex patterns that collectively handle these different log formats.
+
+For each pattern:
+1. Use JavaScript regex syntax with named capture groups (e.g., "(?<severity>INFO|ERROR)")
+2. Include a clear description of what types of logs the pattern matches
+3. Include an "extractionMap" that maps regex capture group names to LogEntry field names
+
+The pattern should be comprehensive enough to extract:
+- severity: The log severity level if present (INFO, DEBUG, ERROR, etc.)
+- timestamp: The timestamp in any format, if present
+- message: The main log message content
+- serviceName: The name of the service or component generating the log
+- fileName: The source file name if present (with or without extension)
+- lineNumber: The line number in the source file if present
+- Any other relevant fields
+
+Ensure the regex patterns:
+- Are compatible with JavaScript's regular expression engine
+- Use named capture groups for all extracted fields
+- Are flexible enough to handle variations in format
+- Are precise enough to avoid false positives
+- Collectively cover all the provided log samples
+- Handle both structured and unstructured log formats
+
+Your response must be in JSON format with the following structure:
+{
+  "patterns": [
+    {
+      "pattern": "regex pattern string",
+      "description": "Description of what this pattern matches",
+      "extractionMap": {
+        "severity": "severityGroup",
+        "timestamp": "timestampGroup",
+        "message": "messageGroup"
+      }
+    }
+  ]
+}`;
+
+            const response = await this.callOllama(prompt);
+            const jsonResponse = this.extractJsonFromResponse(response);
+            return this.validateRegexPatternsResponse(jsonResponse);
+        } catch (error) {
+            console.error('Error generating regex patterns with Ollama:', error);
+            throw new Error('Failed to generate regex patterns with Ollama');
+        }
+    }
+
+    private async callOllama(prompt: string): Promise<string> {
+        if (!this.endpoint) {
+            throw new Error('Ollama endpoint not set');
+        }
+
+        try {
+            console.log(`OllamaService: Calling Ollama at ${this.endpoint} with model ${this.model}`);
+            
+            // Format the request according to Ollama API
+            const request = {
+                model: this.model,
+                prompt: prompt,
+                stream: false,
+                options: {
+                    temperature: 0.1, // Low temperature for more deterministic responses
+                    num_predict: 2048 // Reasonable token limit for responses
+                },
+                format: 'json' // Request JSON format if the model supports it
+            };
+
+            console.log('OllamaService: Sending request to Ollama');
+            
+            // Try to catch connection errors
+            let response;
+            try {
+                response = await fetch(`${this.endpoint}/api/generate`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json'
+                    },
+                    body: JSON.stringify(request),
+                    // Add a reasonable timeout
+                    timeout: 30000
+                });
+            } catch (fetchError) {
+                console.error('OllamaService: Network error when connecting to Ollama:', fetchError);
+                if (fetchError instanceof Error) {
+                    if (fetchError.message.includes('ECONNREFUSED')) {
+                        throw new Error(`Connection refused to Ollama at ${this.endpoint}. Is Ollama running?`);
+                    }
+                    if (fetchError.message.includes('ETIMEDOUT') || fetchError.message.includes('timeout')) {
+                        throw new Error(`Connection to Ollama timed out. Check if Ollama is running at ${this.endpoint}`);
+                    }
+                }
+                throw new Error(`Network error connecting to Ollama: ${fetchError}`);
+            }
+
+            if (!response.ok) {
+                const errorText = await response.text();
+                console.error(`OllamaService: Ollama API error: ${response.status} ${response.statusText}`);
+                console.error(`OllamaService: Error details: ${errorText}`);
+                throw new Error(`Ollama API error: ${response.statusText}\nDetails: ${errorText}`);
+            }
+
+            console.log('OllamaService: Received successful response from Ollama');
+            
+            const responseData = await response.json();
+            return responseData.response || '';
+        } catch (error) {
+            console.error('Error calling Ollama API:', error);
+            throw error;
+        }
+    }
+
+    // Helper method to extract JSON from text response
+    private extractJsonFromResponse(text: string): any {
+        // Try to find JSON content in the response
+        const jsonMatch = text.match(/\{[\s\S]*\}/);
+        if (jsonMatch) {
+            try {
+                return JSON.parse(jsonMatch[0]);
+            } catch (e) {
+                console.warn('Failed to parse JSON from response:', e);
+            }
+        }
+
+        // If no JSON found or parsing failed, try to extract from markdown code block
+        const codeBlockMatch = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
+        if (codeBlockMatch) {
+            try {
+                return JSON.parse(codeBlockMatch[1]);
+            } catch (e) {
+                console.warn('Failed to parse JSON from code block:', e);
+            }
+        }
+
+        throw new Error('Failed to extract valid JSON from Ollama response');
+    }
+
+    // Validate and fix log analysis response
+    private validateLogAnalysisResponse(response: any, logMessage: string): LLMLogAnalysis {
+        if (!response) {
+            response = {};
+        }
+
+        // Validate required fields are present
+        if (!Object.prototype.hasOwnProperty.call(response, 'staticSearchString')) {
+            console.warn('Ollama response missing staticSearchString, using empty string');
+            response.staticSearchString = '';
+        }
+
+        if (!Object.prototype.hasOwnProperty.call(response, 'variables')) {
+            console.warn('Ollama response missing variables, using empty object');
+            response.variables = {};
+        }
+
+        // Ensure types are correct
+        if (typeof response.staticSearchString !== 'string') {
+            console.warn('Ollama response staticSearchString is not a string, converting');
+            response.staticSearchString = String(response.staticSearchString || '');
+        }
+
+        if (typeof response.variables !== 'object' || response.variables === null) {
+            console.warn('Ollama response variables is not an object, using empty object');
+            response.variables = {};
+        }
+
+        // Clean up the static search string by removing log level indicators
+        // This helps with matching source code that doesn't include these markers
+        if (response.staticSearchString) {
+            const logLevelPattern = /\[\s*(INFO|DEBUG|WARN|WARNING|ERROR|TRACE)\s*\]\s*/gi;
+            // Store the original search string for debugging
+            const originalSearchString = response.staticSearchString;
+            // Remove log level indicators
+            response.staticSearchString = response.staticSearchString.replace(logLevelPattern, '');
+
+            // Log the change if we modified the search string
+            if (originalSearchString !== response.staticSearchString) {
+                console.log(`Cleaned log level indicators from search string: "${originalSearchString}" → "${response.staticSearchString}"`);
+            }
+        }
+
+        return response as LLMLogAnalysis;
+    }
+
+    // Validate and fix caller analysis response
+    private validateCallerAnalysisResponse(response: any): CallerAnalysis {
+        if (!response || !response.rankedCallers || !Array.isArray(response.rankedCallers)) {
+            console.warn('Invalid rankedCallers in Ollama response, using empty array');
+            response = { rankedCallers: [] };
+        }
+
+        // Validate each ranked caller
+        response.rankedCallers = response.rankedCallers.filter((caller: any) => {
+            if (!caller || typeof caller !== 'object') return false;
+            
+            // Ensure required fields exist and have correct types
+            if (!caller.filePath || typeof caller.filePath !== 'string') return false;
+            if (!caller.functionName || typeof caller.functionName !== 'string') return false;
+            if (typeof caller.lineNumber !== 'number') {
+                try {
+                    caller.lineNumber = parseInt(caller.lineNumber, 10);
+                    if (isNaN(caller.lineNumber)) return false;
+                } catch {
+                    return false;
+                }
+            }
+            
+            if (typeof caller.confidence !== 'number') {
+                try {
+                    caller.confidence = parseFloat(caller.confidence);
+                    if (isNaN(caller.confidence)) caller.confidence = 0.5;
+                } catch {
+                    caller.confidence = 0.5;
+                }
+            }
+            
+            if (!caller.explanation || typeof caller.explanation !== 'string') {
+                caller.explanation = 'No explanation provided';
+            }
+            
+            return true;
+        });
+
+        return response as CallerAnalysis;
+    }
+
+    // Validate and fix regex patterns response
+    private validateRegexPatternsResponse(response: any): RegexPattern[] {
+        let patterns: RegexPattern[] = [];
+        
+        if (!response || !response.patterns || !Array.isArray(response.patterns)) {
+            console.warn('Invalid patterns in Ollama response, using empty array');
+            return patterns;
+        }
+        
+        // Process and validate each pattern
+        patterns = response.patterns.filter((pattern: any) => {
+            if (!pattern || typeof pattern !== 'object') return false;
+            
+            // Ensure required fields exist
+            if (!pattern.pattern || typeof pattern.pattern !== 'string') return false;
+            if (!pattern.description || typeof pattern.description !== 'string') return false;
+            if (!pattern.extractionMap || typeof pattern.extractionMap !== 'object') {
+                pattern.extractionMap = {};
+            }
+            
+            // Validate pattern is a valid regex
+            try {
+                new RegExp(pattern.pattern);
+            } catch (error) {
+                console.warn(`Invalid regex pattern: ${pattern.pattern}`, error);
+                return false;
+            }
+            
+            return true;
+        });
+        
+        return patterns;
+    }
+}

--- a/src/processor.ts
+++ b/src/processor.ts
@@ -5,7 +5,8 @@ import { LogEntry } from './logExplorer';
 import { logLineDecorationType } from './decorations';
 import fetch from 'node-fetch';
 import { Axiom } from '@axiomhq/js';
-import { ClaudeService, RegexPattern } from './claudeService';
+import { RegexPattern } from './llmService';
+import { LLMServiceFactory } from './llmService';
 
 /**
  * Load trace data from Axiom API
@@ -542,7 +543,7 @@ export class PlainTextLogParser implements LogParser {
  * Parser that uses Claude-generated regex patterns to parse log lines
  */
 export class RegexLogParser implements LogParser {
-  private claudeService = ClaudeService.getInstance();
+  private llmService = LLMServiceFactory.getInstance().createLLMService();
   private patterns: RegexPattern[] = [];
   private sampleLogs: string[] = [];
   private maxSampleLogs = 20; // Maximum number of sample logs to collect for pattern generation
@@ -613,7 +614,7 @@ export class RegexLogParser implements LogParser {
       console.log(`Generating regex patterns from ${this.sampleLogs.length} sample logs...`);
 
       // Call Claude to generate patterns
-      this.patterns = await this.claudeService.generateLogParsingRegex(this.sampleLogs);
+      this.patterns = await this.llmService.generateLogParsingRegex(this.sampleLogs);
 
       console.log(`Generated ${this.patterns.length} regex patterns`);
 


### PR DESCRIPTION
### Description

1. feat(ollama): adds support for ollama in addition to Claude

Details (from Claude Code):

  1. Created a `llmService.ts` file with:
    - Common interfaces for LLM services
    - A factory class for creating the appropriate LLM service
    - Utility functions for log filtering
  2. Updated `claudeService.ts` to:
    - Implement the LLMService interface
    - Use the shared utility functions
  3. Created a new ollamaService.ts file that:
    - Implements the LLMService interface
    - Provides methods to call Ollama API
    - Handles JSON parsing and validation
    - Has proper error handling and fallbacks
  4. Updated the UI in `settingsView.ts` to:
    - Add a provider selection dropdown
    - Add Ollama-specific settings
    - Add handlers to save the settings
  5. Added configuration options in package.json:
    - LLM provider selection
    - Ollama endpoint URL
    - Ollama model name
  6. Added new commands in extension.ts:
    - Set Ollama endpoint
    - Set Ollama model
    - Set LLM provider
  7. Updated the README with Ollama setup instructions

### Other changes

1. chore(package.json): bump version to `0.4.15`

### Tested

#### Ollama-mode

**Summary**: Ollama mode _works_, but speed and accuracy is worse. I don't think it's in the scope of this PR. Finding the right model and making sure it works well, will be in a different PR. 

Run ollama:

```
ollama run llama3.2
```

Source: https://github.com/ollama/ollama

Set model in settings:

![image](https://github.com/user-attachments/assets/37c1f595-8f95-4bd8-bed8-8b8bf034185b)

Parse `checkout.log`: seems to work

![image](https://github.com/user-attachments/assets/a501ed29-b64d-48b0-b430-97bfcc0dcf8b)

Code search log line: finds a line, but not the correct line not in the correct file. Accuracy with `llama3.2` is low.

![image](https://github.com/user-attachments/assets/12298403-0116-4a09-9bda-5ad71520239f)

Search string is "checkout"

Log line is:

```
{
  "severity": "INFO",
  "timestamp": "2025-04-25T15:05:48.685Z",
  "rawText": "checkout  | {\"message\":\"[PlaceOrder] user_id=\\\"ad2a8af0-16d1-11f0-9eeb-0242ac120019\\\" user_currency=\\\"CAD\\\"\",\"severity\":\"info\",\"timestamp\":\"2025-04-11T12:37:05.788383761Z\"}",
  "serviceName": "",
  "message": "checkout  | {\"message\":\"[PlaceOrder] user_id=\\\"ad2a8af0-16d1-11f0-9eeb-0242ac120019\\\" user_currency=\\\"CAD\\\"\",\"severity\":\"info\",\"timestamp\":\"2025-04-11T12:37:05.788383761Z\"}",
  "target": "unknown",
  "fileName": "",
  "lineNumber": -1,
  "jsonPayload": {
    "fields": {
      "message": "checkout  | {\"message\":\"[PlaceOrder] user_id=\\\"ad2a8af0-16d1-11f0-9eeb-0242ac120019\\\" user_currency=\\\"CAD\\\"\",\"severity\":\"info\",\"timestamp\":\"2025-04-11T12:37:05.788383761Z\"}"
    },
    "target": "unknown"
  },
  "codeLocationCache": {
    "file": "src/react-native-app/gateways/Api.gateway.ts",
    "line": 20,
    "lastUpdated": "2025-04-25T15:06:34.933Z"
  }
}
```

VS Code logs: 

```
Log parsed successfully with parser: RegexLogParser
extensionHostProcess.js:179
openLog called with: {severity: 'INFO', timestamp: '2025-04-25T15:05:48.685Z', rawText: 'checkout  | {"message":"[PlaceOrder] user_id…timestamp":"2025-04-11T12:37:05.788383761Z"}', serviceName: '', message: 'checkout  | {"message":"[PlaceOrder] user_id…timestamp":"2025-04-11T12:37:05.788383761Z"}', …}
extensionHostProcess.js:179
OllamaService: Analyzing log message with model: llama3.2
extensionHostProcess.js:179
OllamaService: Using endpoint: http://localhost:11434
extensionHostProcess.js:179
OllamaService: Calling Ollama at http://localhost:11434 with model llama3.2
extensionHostProcess.js:179
OllamaService: Sending request to Ollama
extensionHostProcess.js:179
OllamaService: Received successful response from Ollama
extensionHostProcess.js:179
OllamaService: Got response from Ollama
extensionHostProcess.js:179
OllamaService: Extracted JSON: {"staticSearchString":"checkout","variables":{"user_id":"ad2a8af0-16d1-11f0-9eeb-0242ac120019","user...
extensionHostProcess.js:179
Searching all 218 files in the codebase
extensionHostProcess.js:179
Generated search variations: (1) ['checkout']
extensionHostProcess.js:179
Found match with variation: checkout
extensionHostProcess.js:179
Document language ID: typescript
extensionHostProcess.js:179
TypeScript symbols: (4) [r, r, r, r]
extensionHostProcess.js:179
No enclosing function/method found
```

#### Claude-mode

Checking for regressions

- [ ] Hyperlane
- [ ] Boomerang
- [ ] Neon
- [ ] OTEL playground




### Related issues

N/A

<!-- Linear magic words

1. Closing 
  1. close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing
  3. move the issue to In Progress when the branch is pushed and Done when the commit is merged to the default branch
2. Non-closing
  1. ref, references, part of, related to, contributes to, towards
  2. will not close the issue when the PR or commit merges
-->

### Backwards compatibility

Yes, Claude works like before. Just adds a new option for ollama.

### Documentation

Run ollama:

```
ollama run llama3.2
```

Source: https://github.com/ollama/ollama

| Model              | Parameters | Size  | Download                         |
| ------------------ | ---------- | ----- | -------------------------------- |
| Gemma 3            | 1B         | 815MB | `ollama run gemma3:1b`           |
| Gemma 3            | 4B         | 3.3GB | `ollama run gemma3`              |
| Gemma 3            | 12B        | 8.1GB | `ollama run gemma3:12b`          |
| Gemma 3            | 27B        | 17GB  | `ollama run gemma3:27b`          |
| QwQ                | 32B        | 20GB  | `ollama run qwq`                 |
| DeepSeek-R1        | 7B         | 4.7GB | `ollama run deepseek-r1`         |
| DeepSeek-R1        | 671B       | 404GB | `ollama run deepseek-r1:671b`    |
| Llama 3.3          | 70B        | 43GB  | `ollama run llama3.3`            |
| Llama 3.2          | 3B         | 2.0GB | `ollama run llama3.2`            |
| Llama 3.2          | 1B         | 1.3GB | `ollama run llama3.2:1b`         |
| Llama 3.2 Vision   | 11B        | 7.9GB | `ollama run llama3.2-vision`     |
| Llama 3.2 Vision   | 90B        | 55GB  | `ollama run llama3.2-vision:90b` |
| Llama 3.1          | 8B         | 4.7GB | `ollama run llama3.1`            |
| Llama 3.1          | 405B       | 231GB | `ollama run llama3.1:405b`       |
| Phi 4              | 14B        | 9.1GB | `ollama run phi4`                |
| Phi 4 Mini         | 3.8B       | 2.5GB | `ollama run phi4-mini`           |
| Mistral            | 7B         | 4.1GB | `ollama run mistral`             |
| Moondream 2        | 1.4B       | 829MB | `ollama run moondream`           |
| Neural Chat        | 7B         | 4.1GB | `ollama run neural-chat`         |
| Starling           | 7B         | 4.1GB | `ollama run starling-lm`         |
| Code Llama         | 7B         | 3.8GB | `ollama run codellama`           |
| Llama 2 Uncensored | 7B         | 3.8GB | `ollama run llama2-uncensored`   |
| LLaVA              | 7B         | 4.5GB | `ollama run llava`               |
| Granite-3.2         | 8B         | 4.9GB | `ollama run granite3.2`          |

> [!NOTE]
> You should have at least 8 GB of RAM available to run the 7B models, 16 GB to run the 13B models, and 32 GB to run the 33B models.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR introduces support for the `Ollama` local LLM alongside the existing `Claude` API, allowing users to configure settings for both providers. It also refactors related services and updates the UI to manage these configurations.

### Detailed summary
- Added configuration options for `Ollama` in `package.json`.
- Introduced commands to set `Ollama` endpoint, model, and LLM provider.
- Updated `README.md` with instructions for using `Ollama`.
- Refactored `claudeService` to `llmService` for unified handling.
- Created `OllamaService` class for local LLM interactions.
- Updated UI in `settingsView.ts` for selecting LLM provider and settings.
- Modified log analysis and regex generation methods to utilize the appropriate LLM service based on the selected provider.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->